### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/scw_js/readhandler_v2.js
+++ b/scw_js/readhandler_v2.js
@@ -126,6 +126,14 @@ async function handle(event, context, cb) {
     if (!allowedHostnames.includes(url.hostname)) {
       throw new Error(`Untrusted metadata URL: ${metadataUrl}`);
     }
+    // Additional validation for pathname and query parameters
+    const forbiddenPatterns = ["../", "..\\"];
+    if (forbiddenPatterns.some(pattern => url.pathname.includes(pattern))) {
+      throw new Error(`Invalid metadata URL pathname: ${metadataUrl}`);
+    }
+    if (url.search && url.search.includes("redirect")) {
+      throw new Error(`Invalid metadata URL query parameters: ${metadataUrl}`);
+    }
 
     const metadataResponse = await fetch(metadataUrl);
     if (!metadataResponse.ok) {


### PR DESCRIPTION
Potential fix for [https://github.com/fretchen/fretchen.github.io/security/code-scanning/5](https://github.com/fretchen/fretchen.github.io/security/code-scanning/5)

To fix the SSRF vulnerability, we need to ensure that the `metadataUrl` is fully validated and sanitized before being used in the `fetch()` call. This involves:
1. Restricting the `metadataUrl` to a trusted domain and validating its structure.
2. Ensuring that the URL does not contain malicious path traversal (`../`) or query parameters that could redirect the request to unintended endpoints.
3. Using a library like `validator` or `url` to validate and sanitize the URL.

The best approach is to:
- Parse the `metadataUrl` using `new URL()` to ensure it is a valid URL.
- Validate the hostname against the allow-list (`allowedHostnames`).
- Check the pathname for malicious patterns (e.g., path traversal).
- Reject the URL if it fails any of these checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
