### PR TITLE
Use tanstack better

### DIFF
--- a/website/components/CommentsSection.tsx
+++ b/website/components/CommentsSection.tsx
@@ -41,7 +41,11 @@ export function CommentsSection() {
   const [success, setSuccess] = useState(false);
   const honeypotRef = useRef<HTMLInputElement>(null);
 
-  const { data: comments = [], isPending } = useQuery({
+  const {
+    data: comments = [],
+    isPending,
+    isError: isFetchError,
+  } = useQuery({
     queryKey: ["comments", urlPathname],
     queryFn: () => fetchComments(urlPathname),
   });
@@ -126,6 +130,8 @@ export function CommentsSection() {
 
       {isPending ? (
         <p className={commentSection.loading}>Loading comments...</p>
+      ) : isFetchError ? (
+        <p className={commentSection.errorMsg}>Could not load comments. Please try again later.</p>
       ) : comments.length === 0 ? (
         <p className={commentSection.empty}>No comments yet — be the first!</p>
       ) : (

--- a/website/components/CommentsSection.tsx
+++ b/website/components/CommentsSection.tsx
@@ -15,6 +15,7 @@ interface Comment {
 
 async function fetchComments(page: string): Promise<Comment[]> {
   const r = await fetch(`${API_URL}?page=${encodeURIComponent(page)}`);
+  if (!r.ok) throw new Error(`Failed to load comments: ${r.status}`);
   const data = (await r.json()) as { comments?: Comment[] };
   return data.comments ?? [];
 }

--- a/website/components/CommentsSection.tsx
+++ b/website/components/CommentsSection.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePageContext } from "vike-react/usePageContext";
 import { commentSection } from "../layouts/styles";
 
@@ -12,76 +13,78 @@ interface Comment {
   suspectedAgent?: boolean;
 }
 
+async function fetchComments(page: string): Promise<Comment[]> {
+  const r = await fetch(`${API_URL}?page=${encodeURIComponent(page)}`);
+  const data = (await r.json()) as { comments?: Comment[] };
+  return data.comments ?? [];
+}
+
+async function postComment(body: { name?: string; text: string; page: string; website: string }): Promise<Comment> {
+  const res = await fetch(API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = (await res.json()) as { error?: string };
+    throw new Error(data.error ?? "Failed to post comment");
+  }
+  const data = (await res.json()) as { comment: Comment };
+  return data.comment;
+}
+
 export function CommentsSection() {
   const { urlPathname } = usePageContext();
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [text, setText] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const honeypotRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    fetch(`${API_URL}?page=${encodeURIComponent(urlPathname)}`)
-      .then((r) => r.json() as Promise<{ comments?: Comment[] }>)
-      .then((data) => {
-        setComments(data.comments ?? []);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, [urlPathname]);
+  const { data: comments = [], isPending } = useQuery({
+    queryKey: ["comments", urlPathname],
+    queryFn: () => fetchComments(urlPathname),
+  });
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!text.trim()) {
-      return;
-    }
-    setSubmitting(true);
-    setError(null);
-
-    try {
-      const res = await fetch(API_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: name.trim() || undefined,
-          text: text.trim(),
-          page: urlPathname,
-          website: honeypotRef.current?.value || "",
-        }),
-      });
-      if (!res.ok) {
-        const data = (await res.json()) as { error?: string };
-        throw new Error(data.error ?? "Failed to post comment");
-      }
-      const data = (await res.json()) as { comment: Comment };
-      setComments((prev) => [...prev, data.comment]);
+  const {
+    mutate: submitComment,
+    isPending: submitting,
+    error: mutationError,
+  } = useMutation({
+    mutationFn: postComment,
+    onSuccess: (newComment) => {
+      queryClient.setQueryData<Comment[]>(["comments", urlPathname], (prev = []) => [...prev, newComment]);
       setText("");
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to post comment");
-    } finally {
-      setSubmitting(false);
-    }
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    submitComment({
+      name: name.trim() || undefined,
+      text: text.trim(),
+      page: urlPathname,
+      website: honeypotRef.current?.value ?? "",
+    });
   };
 
   const commentCount = comments.length;
+  const error =
+    mutationError instanceof Error ? mutationError.message : mutationError ? "Failed to post comment" : null;
 
   return (
     <div className={commentSection.container}>
-      {/* Section title */}
       <h3 className={commentSection.title}>
-        {loading
+        {isPending
           ? "Comments"
           : commentCount === 0
             ? "Comments"
             : `${commentCount} Comment${commentCount !== 1 ? "s" : ""}`}
       </h3>
 
-      {/* Comment form — always visible */}
       <form onSubmit={handleSubmit} className={commentSection.form}>
         <input
           type="text"
@@ -121,8 +124,7 @@ export function CommentsSection() {
         </div>
       </form>
 
-      {/* Comment list */}
-      {loading ? (
+      {isPending ? (
         <p className={commentSection.loading}>Loading comments...</p>
       ) : comments.length === 0 ? (
         <p className={commentSection.empty}>No comments yet — be the first!</p>

--- a/website/components/LeafHistorySidebar.tsx
+++ b/website/components/LeafHistorySidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { formatEther } from "viem";
 
-// Types
 interface LeafHistoryItem {
   id: number;
   user: string;
@@ -14,45 +14,26 @@ interface LeafHistoryItem {
   root?: string;
 }
 
-interface LeafHistoryResponse {
-  leaves: LeafHistoryItem[];
-  count: number;
-}
-
 interface LeafHistorySidebarProps {
   address: `0x${string}` | undefined;
   isOpen: boolean;
   onClose: () => void;
 }
 
+const LEAF_BASE_URL = "https://mypersonaljscloudivnad9dy-leafhistory.functions.fnc.fr-par.scw.cloud";
+
+async function fetchLeafHistory(address: string): Promise<LeafHistoryItem[]> {
+  const response = await fetch(`${LEAF_BASE_URL}?address=${address}`);
+  const data = (await response.json()) as { leaves?: LeafHistoryItem[] };
+  return data.leaves ?? [];
+}
+
 export default function LeafHistorySidebar({ address, isOpen, onClose }: LeafHistorySidebarProps) {
-  const [leaves, setLeaves] = useState<LeafHistoryItem[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const fetchLeafHistory = useCallback(async () => {
-    if (!address) return;
-
-    setLoading(true);
-    try {
-      const LEAF_BASE_URL = "https://mypersonaljscloudivnad9dy-leafhistory.functions.fnc.fr-par.scw.cloud";
-      const response = await fetch(`${LEAF_BASE_URL}?address=${address}`);
-      const data = (await response.json()) as LeafHistoryResponse;
-      setLeaves(data.leaves || []);
-    } catch (error) {
-      console.error("Failed to fetch leaf history:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, [address]);
-
-  // Async fetch drives state updates — no synchronous alternative for remote data.
-
-  useEffect(() => {
-    if (isOpen && address) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      void fetchLeafHistory();
-    }
-  }, [isOpen, address, fetchLeafHistory]);
+  const { data: leaves = [], isPending } = useQuery({
+    queryKey: ["leafHistory", address],
+    queryFn: () => fetchLeafHistory(address!),
+    enabled: isOpen && !!address,
+  });
 
   if (!isOpen) return null;
 
@@ -86,7 +67,7 @@ export default function LeafHistorySidebar({ address, isOpen, onClose }: LeafHis
         </button>
       </div>
 
-      {loading ? (
+      {isPending ? (
         <div>Loading...</div>
       ) : (
         <div>
@@ -96,7 +77,6 @@ export default function LeafHistorySidebar({ address, isOpen, onClose }: LeafHis
             <div style={{ textAlign: "center", color: "#999", marginTop: "2rem" }}>No requests found</div>
           ) : (
             leaves.slice(0, 10).map((leaf) => {
-              // Determine status colors and text
               const getStatusStyle = (processed: boolean) => {
                 if (processed) {
                   return {

--- a/website/components/NFTCard.tsx
+++ b/website/components/NFTCard.tsx
@@ -1,14 +1,23 @@
 import React, { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useWriteContract, useWaitForTransactionReceipt, useSwitchChain } from "wagmi";
 import { useNFTListedStatus } from "../hooks/useNFTListedStatus";
 import { getGenAiNFTAddress, GenImNFTv4ABI, fromCAIP2 } from "@fretchen/chain-utils";
 import { useConfiguredPublicClient } from "../hooks/useConfiguredPublicClient";
-import { NFTCardProps, NFT, NFTMetadata } from "../types/components";
+import { NFTCardProps, NFTMetadata } from "../types/components";
 import { useToast } from "./Toast";
 import { SimpleCollectButton } from "./SimpleCollectButton";
 import { ChainBadge } from "./ChainBadge";
 import * as styles from "../layouts/styles";
 import { useLocale } from "../hooks/useLocale";
+
+type NFTQueryData = {
+  tokenURI: string;
+  imageUrl: string | undefined;
+  metadata: NFTMetadata | undefined;
+  owner: string;
+};
+
 // NFT Card Component
 export function NFTCard({
   tokenId,
@@ -25,16 +34,6 @@ export function NFTCard({
   const { writeContract: writeListingContract, isPending: isToggling, data: listingHash } = useWriteContract();
   const { switchChainAsync } = useSwitchChain();
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
-
-  // NFT state - initialize with preloaded data if available
-  const [nft, setNft] = useState<NFT>({
-    tokenId,
-    tokenURI: "",
-    imageUrl: preloadedImageUrl,
-    metadata: preloadedMetadata,
-    isLoading: !preloadedImageUrl, // Not loading if we have preloaded data
-  });
-  const [owner, setOwner] = useState<string>("");
 
   // Use the new toast hook
   const { showToast, ToastComponent } = useToast();
@@ -60,118 +59,86 @@ export function NFTCard({
     }
   };
 
+  // Use the custom hook for a stable public client reference
+  const publicClient = useConfiguredPublicClient(network);
+
+  const {
+    data: nftQueryData,
+    isPending: nftLoading,
+    isError: nftIsError,
+    error: nftQueryError,
+  } = useQuery<NFTQueryData>({
+    queryKey: ["nftData", tokenId.toString(), network, isPublicView],
+    queryFn: async () => {
+      const tokenURI = await publicClient.readContract({
+        address: contractAddress,
+        abi: GenImNFTv4ABI,
+        functionName: "tokenURI",
+        args: [tokenId],
+      });
+
+      let metadata: NFTMetadata | undefined = preloadedMetadata;
+      let imageUrl: string | undefined = preloadedImageUrl;
+      let owner = "";
+
+      if (!tokenURI && (preloadedImageUrl || preloadedMetadata)) {
+        return { tokenURI: "", imageUrl, metadata, owner };
+      }
+
+      if (isPublicView) {
+        const ownerResult = await publicClient.readContract({
+          address: contractAddress,
+          abi: GenImNFTv4ABI,
+          functionName: "ownerOf",
+          args: [tokenId],
+        });
+        owner = ownerResult as string;
+      }
+
+      if (tokenURI && !tokenURI.startsWith("file://")) {
+        try {
+          const response = await fetch(tokenURI);
+          if (response.ok) {
+            const contractMetadata = (await response.json()) as NFTMetadata;
+            metadata = contractMetadata;
+            imageUrl = contractMetadata.image;
+          }
+        } catch {
+          // keep preloaded fallback
+        }
+      }
+
+      return { tokenURI, imageUrl, metadata, owner };
+    },
+    placeholderData:
+      preloadedImageUrl || preloadedMetadata
+        ? { tokenURI: "", imageUrl: preloadedImageUrl, metadata: preloadedMetadata, owner: "" }
+        : undefined,
+  });
+
+  const nft = {
+    tokenId,
+    tokenURI: nftQueryData?.tokenURI ?? "",
+    imageUrl: nftQueryData?.imageUrl,
+    metadata: nftQueryData?.metadata,
+    isLoading: nftLoading,
+    error: nftIsError
+      ? `Failed to load NFT #${tokenId}: ${nftQueryError instanceof Error ? nftQueryError.message : "Unknown error"}`
+      : undefined,
+  };
+  const owner = nftQueryData?.owner ?? "";
+
   // Use the extracted hook for listing status
   // Only enabled when:
   // 1. Not public view (owners can toggle listing)
   // 2. Token data loaded successfully (no error, not loading)
   // This prevents contract calls for non-existent/burned tokens
-  const tokenDataLoaded = !nft.isLoading && !nft.error;
+  const tokenDataLoaded = !nftLoading && !nftIsError;
   const { isListed, setOptimisticListed } = useNFTListedStatus({
     tokenId,
     network,
     enabled: !isPublicView && tokenDataLoaded,
   });
-
-  // Use the custom hook for a stable public client reference
-  const publicClient = useConfiguredPublicClient(network);
-
-  // Fetch metadata from tokenURI
-  const fetchNFTMetadata = async (tokenURI: string): Promise<NFTMetadata | null> => {
-    try {
-      // Handle file:// URLs for local development
-      if (tokenURI.startsWith("file://")) {
-        console.warn("Cannot fetch file:// URLs in browser. Metadata:", tokenURI);
-        return null;
-      }
-
-      const response = await fetch(tokenURI);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch metadata: ${response.status}`);
-      }
-
-      const metadata = (await response.json()) as NFTMetadata;
-      return metadata;
-    } catch (error) {
-      console.error("Error fetching NFT metadata:", error);
-      return null;
-    }
-  };
-
-  // Load NFT data from blockchain
-  useEffect(() => {
-    const loadNFTData = async () => {
-      try {
-        setNft((prev) => ({ ...prev, isLoading: true, error: undefined }));
-
-        // Get token URI using public client
-        const tokenURIResult = await publicClient.readContract({
-          address: contractAddress,
-          abi: GenImNFTv4ABI,
-          functionName: "tokenURI",
-          args: [tokenId],
-        });
-
-        const tokenURI = tokenURIResult;
-
-        // Skip fetching if tokenURI is empty and we have preloaded data
-        if (!tokenURI && (preloadedImageUrl || preloadedMetadata)) {
-          setNft((prev) => ({
-            ...prev,
-            tokenURI: "",
-            isLoading: false,
-          }));
-          return;
-        }
-
-        // Get owner if in public view
-        let nftOwner = "";
-        if (isPublicView) {
-          const ownerResult = await publicClient.readContract({
-            address: contractAddress,
-            abi: GenImNFTv4ABI,
-            functionName: "ownerOf",
-            args: [tokenId],
-          });
-          nftOwner = ownerResult as string;
-          setOwner(nftOwner);
-        }
-
-        // Note: isListed is now handled by useNFTListedStatus hook
-
-        // Fetch metadata only if tokenURI is available
-        let metadata = preloadedMetadata; // Keep preloaded metadata as fallback
-        let finalImageUrl = preloadedImageUrl; // Keep preloaded image as fallback
-
-        if (tokenURI) {
-          const contractMetadata = await fetchNFTMetadata(tokenURI);
-          if (contractMetadata) {
-            metadata = contractMetadata;
-            finalImageUrl = contractMetadata.image;
-          }
-        }
-
-        setNft({
-          tokenId,
-          tokenURI,
-          metadata,
-          imageUrl: finalImageUrl,
-          isLoading: false,
-        });
-      } catch (error) {
-        console.error(`Error loading NFT ${tokenId}:`, error);
-        setNft({
-          tokenId,
-          tokenURI: "",
-          imageUrl: preloadedImageUrl, // Keep preloaded image on error
-          metadata: preloadedMetadata, // Keep preloaded metadata on error
-          isLoading: false,
-          error: `Failed to load NFT #${tokenId}: ${error instanceof Error ? error.message : "Unknown error"}`,
-        });
-      }
-    };
-
-    void loadNFTData();
-  }, [tokenId, isPublicView, preloadedImageUrl, preloadedMetadata, publicClient, contractAddress]);
 
   // Warte auf Transaktionsbestätigung für Burn
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({

--- a/website/components/NFTCard.tsx
+++ b/website/components/NFTCard.tsx
@@ -405,7 +405,7 @@ export function NFTCard({
               </button>
 
               {/* Listed Toggle (nur private view) */}
-              {!isPublicView && onListedStatusChanged && isListed !== undefined && (
+              {!isPublicView && onListedStatusChanged && isListed !== undefined && isListed !== null && (
                 <button
                   onClick={(e) => {
                     e.stopPropagation();

--- a/website/components/NFTFloatImage.tsx
+++ b/website/components/NFTFloatImage.tsx
@@ -1,103 +1,62 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useAutoNetwork } from "../hooks/useAutoNetwork";
 import { getGenAiNFTAddress, GenImNFTv4ABI, GENAI_NFT_NETWORKS } from "@fretchen/chain-utils";
 import { useConfiguredPublicClient } from "../hooks/useConfiguredPublicClient";
 import { extractPromptFromDescription } from "../utils/nftMetadataUtils";
+import { NFTMetadata } from "../types/components";
 import * as styles from "../layouts/styles";
 
 interface NFTFloatImageProps {
   tokenId: number;
 }
 
-import { NFTMetadata } from "../types/components";
+type NFTFloatData = {
+  imageUrl: string | null;
+  title: string | null;
+  description: string | null;
+};
 
 export function NFTFloatImage({ tokenId }: NFTFloatImageProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [nftTitle, setNftTitle] = useState<string | null>(null);
-  const [nftDescription, setNftDescription] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  // Get network and contract address from chain-utils
   const { network } = useAutoNetwork(GENAI_NFT_NETWORKS);
   const contractAddress = getGenAiNFTAddress(network);
-
-  // Extract prompt from description for display (reusing utility function)
-  const getPromptPreview = (description: string | null): string => {
-    if (!description) return "";
-    return extractPromptFromDescription(description, 60);
-  };
-
-  // Create descriptive title for the image
-  const getImageTitle = (): string => {
-    const promptPreview = getPromptPreview(nftDescription);
-    if (promptPreview) {
-      return `Article Illustration: ${promptPreview}`;
-    }
-    return nftTitle ? `Article Illustration: ${nftTitle}` : `Article Illustration: NFT #${tokenId}`;
-  };
-
-  // Use the custom hook for a stable public client reference
   const publicClient = useConfiguredPublicClient(network);
 
-  // Fetch metadata from tokenURI
-  const fetchNFTMetadata = async (tokenURI: string): Promise<NFTMetadata | null> => {
-    try {
-      if (tokenURI.startsWith("file://")) {
-        console.warn("Cannot fetch file:// URLs in browser. Metadata:", tokenURI);
-        return null;
+  const { data, isPending, isError } = useQuery<NFTFloatData>({
+    queryKey: ["nftFloatData", tokenId, network],
+    queryFn: async () => {
+      const tokenURI = await publicClient.readContract({
+        address: contractAddress,
+        abi: GenImNFTv4ABI,
+        functionName: "tokenURI",
+        args: [BigInt(tokenId)],
+      });
+
+      if (!tokenURI || tokenURI.startsWith("file://")) {
+        return { imageUrl: null, title: null, description: null };
       }
 
       const response = await fetch(tokenURI);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch metadata: ${response.status}`);
-      }
-
+      if (!response.ok) throw new Error(`Failed to fetch metadata: ${response.status}`);
       const metadata = (await response.json()) as NFTMetadata;
-      return metadata;
-    } catch (error) {
-      console.error("Error fetching NFT metadata:", error);
-      return null;
-    }
+
+      return {
+        imageUrl: metadata.image ?? null,
+        title: metadata.name ?? null,
+        description: metadata.description ?? null,
+      };
+    },
+  });
+
+  const getImageTitle = (): string => {
+    const description = data?.description ?? null;
+    const title = data?.title ?? null;
+    const promptPreview = description ? extractPromptFromDescription(description, 60) : "";
+    if (promptPreview) return `Article Illustration: ${promptPreview}`;
+    return title ? `Article Illustration: ${title}` : `Article Illustration: NFT #${tokenId}`;
   };
 
-  useEffect(() => {
-    const loadNFTData = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        // Get token URI using public client
-        const tokenURIResult = await publicClient.readContract({
-          address: contractAddress,
-          abi: GenImNFTv4ABI,
-          functionName: "tokenURI",
-          args: [BigInt(tokenId)],
-        });
-
-        const tokenURI = tokenURIResult;
-
-        // Fetch metadata
-        const metadata = await fetchNFTMetadata(tokenURI);
-
-        if (metadata) {
-          setImageUrl(metadata.image || null);
-          setNftTitle(metadata.name || null);
-          setNftDescription(metadata.description || null);
-        }
-
-        setIsLoading(false);
-      } catch (error) {
-        console.error(`Error loading NFT ${tokenId}:`, error);
-        setError(`Failed to load NFT #${tokenId}`);
-        setIsLoading(false);
-      }
-    };
-
-    void loadNFTData();
-  }, [tokenId, publicClient, contractAddress]);
-
-  if (isLoading) {
+  if (isPending) {
     return (
       <div className={styles.nftFloat.container}>
         <div className={styles.nftFloat.loading}>
@@ -108,7 +67,7 @@ export function NFTFloatImage({ tokenId }: NFTFloatImageProps) {
     );
   }
 
-  if (error || !imageUrl) {
+  if (isError || !data?.imageUrl) {
     return (
       <div className={styles.nftFloat.container}>
         <div className={styles.nftFloat.placeholder}>
@@ -121,7 +80,7 @@ export function NFTFloatImage({ tokenId }: NFTFloatImageProps) {
 
   return (
     <div className={styles.nftFloat.container}>
-      <img src={imageUrl} alt={nftTitle || `NFT #${tokenId}`} className={`u-photo ${styles.nftFloat.image}`} />
+      <img src={data.imageUrl} alt={data.title || `NFT #${tokenId}`} className={`u-photo ${styles.nftFloat.image}`} />
       <p className={styles.nftFloat.caption}>{getImageTitle()}</p>
     </div>
   );

--- a/website/components/Webmentions.tsx
+++ b/website/components/Webmentions.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { webmentions } from "../layouts/styles";
 import { useWebmentionUrls } from "../hooks/useWebmentionUrls";
 import { fetchWebmentions } from "../utils/webmentionUtils";
@@ -54,17 +55,15 @@ function ShareActions({ urlWithoutSlash }: { urlWithoutSlash: string }) {
 
 export function Webmentions() {
   const { urlWithoutSlash, urlWithSlash } = useWebmentionUrls();
-  const [mentions, setMentions] = useState<Webmention[] | null>(null);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    void fetchWebmentions(urlWithoutSlash, urlWithSlash).then(({ mentions }) => {
-      setMentions(mentions);
-      setLoading(false);
-    });
-  }, [urlWithoutSlash, urlWithSlash]);
+  const { data, isPending } = useQuery({
+    queryKey: ["webmentions", urlWithoutSlash],
+    queryFn: () => fetchWebmentions(urlWithoutSlash, urlWithSlash),
+  });
 
-  if (loading) {
+  const mentions = data?.mentions ?? null;
+
+  if (isPending) {
     return (
       <div className={webmentions.loadingState}>
         <span>⏳</span> Loading reactions...
@@ -72,7 +71,6 @@ export function Webmentions() {
     );
   }
 
-  // Empty state — only share actions
   if (!mentions || mentions.length === 0) {
     return (
       <div className={webmentions.container}>
@@ -82,19 +80,15 @@ export function Webmentions() {
     );
   }
 
-  // Group by type
-  const replies = mentions.filter((m) => ["in-reply-to", "mention-of"].includes(m["wm-property"]));
-  const likes = mentions.filter((m) => m["wm-property"] === "like-of");
-  const reposts = mentions.filter((m) => m["wm-property"] === "repost-of");
-
-  // Collect all avatars from likes + reposts for the compact bar
+  const replies = (mentions as Webmention[]).filter((m) => ["in-reply-to", "mention-of"].includes(m["wm-property"]));
+  const likes = (mentions as Webmention[]).filter((m) => m["wm-property"] === "like-of");
+  const reposts = (mentions as Webmention[]).filter((m) => m["wm-property"] === "repost-of");
   const allAvatars = [...likes, ...reposts];
 
   return (
     <div className={webmentions.container}>
       <h3 className={webmentions.sectionTitle}>Reactions</h3>
 
-      {/* Compact counts bar */}
       <div className={webmentions.compactBar}>
         <div className={webmentions.compactCounts}>
           {likes.length > 0 && <span className={webmentions.compactCount}>❤️ {likes.length}</span>}
@@ -125,7 +119,6 @@ export function Webmentions() {
         )}
       </div>
 
-      {/* Replies — still rendered as cards */}
       {replies.length > 0 && (
         <ul className={webmentions.replyList}>
           {replies.map((mention) => (

--- a/website/components/Webmentions.tsx
+++ b/website/components/Webmentions.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { webmentions } from "../layouts/styles";
 import { useWebmentionUrls } from "../hooks/useWebmentionUrls";
-import { fetchWebmentions, type Webmention } from "../utils/webmentionUtils";
+import { fetchWebmentions } from "../utils/webmentionUtils";
 
 function ShareActions({ urlWithoutSlash }: { urlWithoutSlash: string }) {
   const shareText =
@@ -101,7 +101,7 @@ export function Webmentions() {
 
       {replies.length > 0 && (
         <ul className={webmentions.replyList}>
-          {replies.map((mention: Webmention) => (
+          {replies.map((mention) => (
             <li key={mention["wm-id"]} className={webmentions.replyCard}>
               <div className={webmentions.replyHeader}>
                 {mention.author.photo ? (

--- a/website/components/Webmentions.tsx
+++ b/website/components/Webmentions.tsx
@@ -2,27 +2,7 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { webmentions } from "../layouts/styles";
 import { useWebmentionUrls } from "../hooks/useWebmentionUrls";
-import { fetchWebmentions } from "../utils/webmentionUtils";
-
-interface WebmentionAuthor {
-  name: string;
-  photo?: string;
-  url?: string;
-}
-
-interface WebmentionContent {
-  text?: string;
-  html?: string;
-}
-
-interface Webmention {
-  "wm-id": number;
-  "wm-property": string;
-  author: WebmentionAuthor;
-  content?: WebmentionContent;
-  published?: string;
-  url: string;
-}
+import { fetchWebmentions, type Webmention } from "../utils/webmentionUtils";
 
 function ShareActions({ urlWithoutSlash }: { urlWithoutSlash: string }) {
   const shareText =
@@ -57,7 +37,7 @@ export function Webmentions() {
   const { urlWithoutSlash, urlWithSlash } = useWebmentionUrls();
 
   const { data, isPending } = useQuery({
-    queryKey: ["webmentions", urlWithoutSlash],
+    queryKey: ["webmentions", urlWithoutSlash, urlWithSlash],
     queryFn: () => fetchWebmentions(urlWithoutSlash, urlWithSlash),
   });
 
@@ -80,9 +60,9 @@ export function Webmentions() {
     );
   }
 
-  const replies = (mentions as Webmention[]).filter((m) => ["in-reply-to", "mention-of"].includes(m["wm-property"]));
-  const likes = (mentions as Webmention[]).filter((m) => m["wm-property"] === "like-of");
-  const reposts = (mentions as Webmention[]).filter((m) => m["wm-property"] === "repost-of");
+  const replies = mentions.filter((m) => ["in-reply-to", "mention-of"].includes(m["wm-property"]));
+  const likes = mentions.filter((m) => m["wm-property"] === "like-of");
+  const reposts = mentions.filter((m) => m["wm-property"] === "repost-of");
   const allAvatars = [...likes, ...reposts];
 
   return (
@@ -121,7 +101,7 @@ export function Webmentions() {
 
       {replies.length > 0 && (
         <ul className={webmentions.replyList}>
-          {replies.map((mention) => (
+          {replies.map((mention: Webmention) => (
             <li key={mention["wm-id"]} className={webmentions.replyCard}>
               <div className={webmentions.replyHeader}>
                 {mention.author.photo ? (

--- a/website/hooks/useAgentInfo.ts
+++ b/website/hooks/useAgentInfo.ts
@@ -1,18 +1,5 @@
-/**
- * Hook to load and parse EIP-8004 agent registration data.
- *
- * Fetches the agent-registration.json from the public folder and provides
- * parsed data for display in the UI.
- *
- * This approach allows for:
- * 1. Same workflow as loading external agent registrations
- * 2. Easy migration to IPFS/S3 later
- * 3. No build-time coupling
- */
+import { useQuery } from "@tanstack/react-query";
 
-import { useState, useEffect, useCallback } from "react";
-
-// EIP-8004 Registration File Schema
 export interface AgentEndpoint {
   name: string;
   endpoint: string;
@@ -32,7 +19,6 @@ export interface AgentRegistration {
   supportedTrust: string[];
 }
 
-// Parsed agent info for UI display
 export interface AgentInfo {
   name: string;
   description: string;
@@ -46,13 +32,9 @@ export interface AgentInfo {
   raw: AgentRegistration | null;
 }
 
-// Parse CAIP-10 address format: eip155:chainId:address
 const parseCAIP10 = (caip10: string): string | null => {
   const parts = caip10.split(":");
-  if (parts.length === 3) {
-    return parts[2]; // Return just the address
-  }
-  return null;
+  return parts.length === 3 ? parts[2] : null;
 };
 
 const DEFAULT_AGENT_URL = "/agent-registration.json";
@@ -82,66 +64,51 @@ const emptyAgent: AgentInfo = {
   raw: null,
 };
 
+async function fetchAgentInfo(agentUrl: string): Promise<AgentInfo> {
+  const response = await fetch(agentUrl);
+  if (!response.ok) throw new Error(`Failed to fetch agent registration: ${response.status}`);
+  const data = (await response.json()) as AgentRegistration;
+
+  const walletEndpoint = data.endpoints.find((e) => e.name === "agentWallet")?.endpoint;
+  const wallet = walletEndpoint ? parseCAIP10(walletEndpoint) : null;
+
+  return {
+    name: data.name,
+    description: data.description,
+    image: data.image,
+    wallet,
+    walletShort: wallet ? `${wallet.slice(0, 6)}...${wallet.slice(-4)}` : null,
+    genimgEndpoint: data.endpoints.find((e) => e.name === "genimg")?.endpoint ?? null,
+    llmEndpoint: data.endpoints.find((e) => e.name === "llm")?.endpoint ?? null,
+    openApiUrl: data.endpoints.find((e) => e.name === "OpenAPI")?.endpoint ?? null,
+    supportedTrust: data.supportedTrust,
+    raw: data,
+  };
+}
+
 export function useAgentInfo(options: UseAgentInfoOptions = {}): UseAgentInfoResult {
   const { agentUrl = DEFAULT_AGENT_URL, autoFetch = true } = options;
 
-  const [agent, setAgent] = useState<AgentInfo>(emptyAgent);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchAgent = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const response = await fetch(agentUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch agent registration: ${response.status}`);
-      }
-
-      const data = (await response.json()) as AgentRegistration;
-
-      // Parse endpoints
-      const walletEndpoint = data.endpoints.find((e) => e.name === "agentWallet")?.endpoint;
-      const wallet = walletEndpoint ? parseCAIP10(walletEndpoint) : null;
-
-      const parsedAgent: AgentInfo = {
-        name: data.name,
-        description: data.description,
-        image: data.image,
-        wallet,
-        walletShort: wallet ? `${wallet.slice(0, 6)}...${wallet.slice(-4)}` : null,
-        genimgEndpoint: data.endpoints.find((e) => e.name === "genimg")?.endpoint || null,
-        llmEndpoint: data.endpoints.find((e) => e.name === "llm")?.endpoint || null,
-        openApiUrl: data.endpoints.find((e) => e.name === "OpenAPI")?.endpoint || null,
-        supportedTrust: data.supportedTrust,
-        raw: data,
-      };
-
-      setAgent(parsedAgent);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown error fetching agent";
-      setError(message);
-      console.error("Agent fetch error:", err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [agentUrl]);
-
-  // Async fetch drives state updates — no synchronous alternative for remote data.
-
-  useEffect(() => {
-    if (autoFetch) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      void fetchAgent();
-    }
-  }, [autoFetch, fetchAgent]);
+  const {
+    data,
+    isPending,
+    isError,
+    error: queryError,
+    refetch,
+  } = useQuery({
+    queryKey: ["agentInfo", agentUrl],
+    queryFn: () => fetchAgentInfo(agentUrl),
+    enabled: autoFetch,
+    staleTime: Infinity,
+  });
 
   return {
-    agent,
-    isLoading,
-    error,
-    refetch: fetchAgent,
+    agent: data ?? emptyAgent,
+    isLoading: isPending && autoFetch,
+    error: isError ? (queryError instanceof Error ? queryError.message : "Unknown error fetching agent") : null,
+    refetch: async () => {
+      await refetch();
+    },
   };
 }
 

--- a/website/hooks/useGrowthApi.ts
+++ b/website/hooks/useGrowthApi.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAccount, useSignMessage } from "wagmi";
 import type { ContentQueue, Draft, Insights, Performance } from "../types/growth";
@@ -9,6 +9,12 @@ const API_BASE =
 
 const AUTH_CACHE_TTL_MS = 4 * 60 * 1000; // 4 minutes (backend allows 5 min)
 
+// Module-level cache shared across all hook instances for the same address.
+// This prevents multiple wallet signature prompts when different hooks (e.g.
+// useGrowthDrafts + useApproveDraft) both call getAuth in the same session.
+const authCacheMap = new Map<string, { token: string; timestamp: number }>();
+const pendingAuthMap = new Map<string, Promise<string>>();
+
 async function createAuthHeader(
   address: string,
   signMessageAsync: (args: { message: string }) => Promise<string>,
@@ -18,6 +24,36 @@ async function createAuthHeader(
   const signature = await signMessageAsync({ message });
   const payload = JSON.stringify({ address, signature, message });
   return `Bearer ${btoa(payload)}`;
+}
+
+async function getOrCreateToken(
+  address: string,
+  signMessageAsync: (args: { message: string }) => Promise<string>,
+): Promise<string> {
+  const cached = authCacheMap.get(address);
+  if (cached && Date.now() - cached.timestamp < AUTH_CACHE_TTL_MS) return cached.token;
+
+  const pending = pendingAuthMap.get(address);
+  if (pending) return pending;
+
+  const promise = createAuthHeader(address, signMessageAsync)
+    .then((token) => {
+      authCacheMap.set(address, { token, timestamp: Date.now() });
+      pendingAuthMap.delete(address);
+      return token;
+    })
+    .catch((err) => {
+      pendingAuthMap.delete(address);
+      throw err;
+    });
+
+  pendingAuthMap.set(address, promise);
+  return promise;
+}
+
+export function clearAuthCacheForTesting() {
+  authCacheMap.clear();
+  pendingAuthMap.clear();
 }
 
 async function apiFetch<T>(path: string, auth: string, options: RequestInit = {}): Promise<T> {
@@ -36,38 +72,14 @@ async function apiFetch<T>(path: string, auth: string, options: RequestInit = {}
   return res.json() as Promise<T>;
 }
 
-// Shared auth getter — keeps signing token cached per address for 4 min.
+// Thin wrapper: supplies current address + signMessageAsync to the shared module-level cache.
 function useGrowthAuth() {
   const { address } = useAccount();
   const { signMessageAsync } = useSignMessage();
-  const authCache = useRef<{ token: string; timestamp: number; address: string } | null>(null);
-  const pendingAuth = useRef<{ promise: Promise<string>; address: string } | null>(null);
 
   return useCallback(async () => {
     if (!address) throw new Error("Wallet not connected");
-
-    const cached = authCache.current;
-    if (cached && cached.address === address && Date.now() - cached.timestamp < AUTH_CACHE_TTL_MS) {
-      return cached.token;
-    }
-
-    if (pendingAuth.current && pendingAuth.current.address === address) {
-      return pendingAuth.current.promise;
-    }
-
-    const promise = createAuthHeader(address, signMessageAsync)
-      .then((token) => {
-        authCache.current = { token, timestamp: Date.now(), address };
-        pendingAuth.current = null;
-        return token;
-      })
-      .catch((err) => {
-        pendingAuth.current = null;
-        throw err;
-      });
-
-    pendingAuth.current = { promise, address };
-    return promise;
+    return getOrCreateToken(address, signMessageAsync);
   }, [address, signMessageAsync]);
 }
 

--- a/website/hooks/useGrowthApi.ts
+++ b/website/hooks/useGrowthApi.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAccount, useSignMessage } from "wagmi";
 import type { ContentQueue, Draft, Insights, Performance } from "../types/growth";
 
@@ -35,22 +36,14 @@ async function apiFetch<T>(path: string, auth: string, options: RequestInit = {}
   return res.json() as Promise<T>;
 }
 
-export interface UseGrowthApi {
-  fetchDrafts: () => Promise<ContentQueue>;
-  fetchInsights: () => Promise<Insights>;
-  fetchPerformance: () => Promise<Performance>;
-  updateDraft: (id: string, body: Partial<Draft>) => Promise<Draft>;
-  approveDraft: (id: string, scheduledAt?: string, reviewComment?: string) => Promise<Draft>;
-  rejectDraft: (id: string, reviewComment?: string) => Promise<Draft>;
-}
-
-export function useGrowthApi(): UseGrowthApi {
+// Shared auth getter — keeps signing token cached per address for 4 min.
+function useGrowthAuth() {
   const { address } = useAccount();
   const { signMessageAsync } = useSignMessage();
   const authCache = useRef<{ token: string; timestamp: number; address: string } | null>(null);
   const pendingAuth = useRef<{ promise: Promise<string>; address: string } | null>(null);
 
-  const getAuth = useCallback(async () => {
+  return useCallback(async () => {
     if (!address) throw new Error("Wallet not connected");
 
     const cached = authCache.current;
@@ -58,7 +51,6 @@ export function useGrowthApi(): UseGrowthApi {
       return cached.token;
     }
 
-    // If a signing request is already in flight for the same address, reuse it
     if (pendingAuth.current && pendingAuth.current.address === address) {
       return pendingAuth.current.promise;
     }
@@ -77,6 +69,137 @@ export function useGrowthApi(): UseGrowthApi {
     pendingAuth.current = { promise, address };
     return promise;
   }, [address, signMessageAsync]);
+}
+
+export function useGrowthDrafts(enabled: boolean) {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+
+  return useQuery<ContentQueue>({
+    queryKey: ["growthDrafts", address],
+    queryFn: async () => {
+      const auth = await getAuth();
+      return apiFetch<ContentQueue>("drafts", auth);
+    },
+    enabled,
+  });
+}
+
+export function useGrowthInsights(enabled: boolean) {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+
+  return useQuery<Insights>({
+    queryKey: ["growthInsights", address],
+    queryFn: async () => {
+      const auth = await getAuth();
+      return apiFetch<Insights>("insights", auth);
+    },
+    enabled,
+  });
+}
+
+export function useUpdateDraft() {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: Partial<Draft> }) => {
+      const auth = await getAuth();
+      return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}`, auth, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ContentQueue>(["growthDrafts", address], (prev) => {
+        if (!prev) return prev;
+        const updateIn = (list: Draft[]) => list.map((d) => (d.id === updated.id ? { ...d, ...updated } : d));
+        return { ...prev, drafts: updateIn(prev.drafts), approved: updateIn(prev.approved) };
+      });
+    },
+  });
+}
+
+export function useApproveDraft() {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      scheduledAt,
+      reviewComment,
+    }: {
+      id: string;
+      scheduledAt?: string;
+      reviewComment?: string;
+    }) => {
+      const auth = await getAuth();
+      const body: Record<string, string> = {};
+      if (scheduledAt) body.scheduled_at = scheduledAt;
+      if (reviewComment) body.review_comment = reviewComment;
+      return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}/approve`, auth, {
+        method: "POST",
+        body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
+      });
+    },
+    onSuccess: (response, { id }) => {
+      queryClient.setQueryData<ContentQueue>(["growthDrafts", address], (prev) => {
+        if (!prev) return prev;
+        const draft = prev.drafts.find((d) => d.id === id);
+        if (!draft) return prev;
+        const updated = { ...draft, ...response };
+        return { ...prev, drafts: prev.drafts.filter((d) => d.id !== id), approved: [...prev.approved, updated] };
+      });
+    },
+  });
+}
+
+export function useRejectDraft() {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, reviewComment }: { id: string; reviewComment?: string }) => {
+      const auth = await getAuth();
+      return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}/reject`, auth, {
+        method: "POST",
+        body: reviewComment ? JSON.stringify({ review_comment: reviewComment }) : undefined,
+      });
+    },
+    onSuccess: (response, { id }) => {
+      queryClient.setQueryData<ContentQueue>(["growthDrafts", address], (prev) => {
+        if (!prev) return prev;
+        const draft = prev.drafts.find((d) => d.id === id) ?? prev.approved.find((d) => d.id === id);
+        if (!draft) return prev;
+        const updated = { ...draft, ...response };
+        return {
+          ...prev,
+          drafts: prev.drafts.filter((d) => d.id !== id),
+          approved: prev.approved.filter((d) => d.id !== id),
+          rejected: [...prev.rejected, updated],
+        };
+      });
+    },
+  });
+}
+
+// Legacy imperative interface kept for backward compatibility
+export interface UseGrowthApi {
+  fetchDrafts: () => Promise<ContentQueue>;
+  fetchInsights: () => Promise<Insights>;
+  fetchPerformance: () => Promise<Performance>;
+  updateDraft: (id: string, body: Partial<Draft>) => Promise<Draft>;
+  approveDraft: (id: string, scheduledAt?: string, reviewComment?: string) => Promise<Draft>;
+  rejectDraft: (id: string, reviewComment?: string) => Promise<Draft>;
+}
+
+export function useGrowthApi(): UseGrowthApi {
+  const getAuth = useGrowthAuth();
 
   const fetchDrafts = useCallback(async () => {
     const auth = await getAuth();
@@ -96,10 +219,7 @@ export function useGrowthApi(): UseGrowthApi {
   const updateDraft = useCallback(
     async (id: string, body: Partial<Draft>) => {
       const auth = await getAuth();
-      return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}`, auth, {
-        method: "PUT",
-        body: JSON.stringify(body),
-      });
+      return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}`, auth, { method: "PUT", body: JSON.stringify(body) });
     },
     [getAuth],
   );
@@ -108,12 +228,8 @@ export function useGrowthApi(): UseGrowthApi {
     async (id: string, scheduledAt?: string, reviewComment?: string) => {
       const auth = await getAuth();
       const body: Record<string, string> = {};
-      if (scheduledAt) {
-        body.scheduled_at = scheduledAt;
-      }
-      if (reviewComment) {
-        body.review_comment = reviewComment;
-      }
+      if (scheduledAt) body.scheduled_at = scheduledAt;
+      if (reviewComment) body.review_comment = reviewComment;
       return apiFetch<Draft>(`drafts/${encodeURIComponent(id)}/approve`, auth, {
         method: "POST",
         body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
@@ -133,8 +249,5 @@ export function useGrowthApi(): UseGrowthApi {
     [getAuth],
   );
 
-  return useMemo(
-    () => ({ fetchDrafts, fetchInsights, fetchPerformance, updateDraft, approveDraft, rejectDraft }),
-    [fetchDrafts, fetchInsights, fetchPerformance, updateDraft, approveDraft, rejectDraft],
-  );
+  return { fetchDrafts, fetchInsights, fetchPerformance, updateDraft, approveDraft, rejectDraft };
 }

--- a/website/hooks/useMultiChainNFTs.ts
+++ b/website/hooks/useMultiChainNFTs.ts
@@ -1,272 +1,146 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 import { readContract } from "wagmi/actions";
 import { config } from "../wagmi.config";
 import { getGenAiNFTAddress, GenImNFTv4ABI, GENAI_NFT_NETWORKS, fromCAIP2, isTestnet } from "@fretchen/chain-utils";
 
-/**
- * NFT with chain information for multi-chain display
- */
 export interface MultiChainNFTToken {
   tokenId: bigint;
   network: string;
 }
 
-/**
- * Options for the useMultiChainUserNFTs hook
- */
 interface UseMultiChainUserNFTsOptions {
-  /** Include testnet NFTs (default: false) */
   includeTestnets?: boolean;
 }
 
-/**
- * Result of the useMultiChainUserNFTs hook
- */
 interface UseMultiChainUserNFTsResult {
-  /** All NFT tokens across chains (sorted by tokenId descending) */
   tokens: MultiChainNFTToken[];
-  /** Loading state */
   isLoading: boolean;
-  /** Error message if any */
   error: string | null;
-  /** Reload all chains */
   reload: () => Promise<void>;
 }
 
-/**
- * Hook to fetch user's NFTs across all configured chains in parallel.
- *
- * @example
- * const { tokens, isLoading, error, reload } = useMultiChainUserNFTs();
- *
- * // tokens = [
- * //   { tokenId: 26n, network: "eip155:10" },
- * //   { tokenId: 1n, network: "eip155:8453" },
- * //   ...
- * // ]
- */
+async function fetchUserTokensOnNetwork(network: string, address: `0x${string}`): Promise<MultiChainNFTToken[]> {
+  const contractAddress = getGenAiNFTAddress(network);
+  const chainId = fromCAIP2(network);
+
+  const balance = await readContract(config, {
+    address: contractAddress,
+    abi: GenImNFTv4ABI,
+    functionName: "balanceOf",
+    args: [address],
+    chainId,
+  });
+
+  if (!balance || balance === 0n) return [];
+
+  const tokenPromises = Array.from({ length: Number(balance) }, (_, i) =>
+    readContract(config, {
+      address: contractAddress,
+      abi: GenImNFTv4ABI,
+      functionName: "tokenOfOwnerByIndex",
+      args: [address, BigInt(i)],
+      chainId,
+    })
+      .then((tokenId) => ({ tokenId, network }) as MultiChainNFTToken)
+      .catch(() => null),
+  );
+
+  const results = await Promise.all(tokenPromises);
+  return results.filter((t): t is MultiChainNFTToken => t !== null);
+}
+
+async function fetchAllUserNFTs(networks: string[], address: `0x${string}`): Promise<MultiChainNFTToken[]> {
+  const networkResults = await Promise.all(
+    networks.map((network) => fetchUserTokensOnNetwork(network, address).catch(() => [] as MultiChainNFTToken[])),
+  );
+  return networkResults.flat().sort((a, b) => (b.tokenId > a.tokenId ? 1 : b.tokenId < a.tokenId ? -1 : 0));
+}
+
 export function useMultiChainUserNFTs(options: UseMultiChainUserNFTsOptions = {}): UseMultiChainUserNFTsResult {
   const { includeTestnets = false } = options;
   const { address, isConnected } = useAccount();
 
-  const [tokens, setTokens] = useState<MultiChainNFTToken[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const networks = useMemo(() => GENAI_NFT_NETWORKS.filter((n) => includeTestnets || !isTestnet(n)), [includeTestnets]);
 
-  // Filter networks based on testnet preference
-  const networks = useMemo(() => {
-    return GENAI_NFT_NETWORKS.filter((n) => includeTestnets || !isTestnet(n));
-  }, [includeTestnets]);
-
-  /**
-   * Fetch all token IDs for a user on a single network
-   */
-  const fetchUserTokensOnNetwork = useCallback(
-    async (network: string): Promise<MultiChainNFTToken[]> => {
-      if (!address) return [];
-
-      const contractAddress = getGenAiNFTAddress(network);
-      const chainId = fromCAIP2(network);
-
-      try {
-        // Get user's balance on this chain
-        const balance = await readContract(config, {
-          address: contractAddress,
-          abi: GenImNFTv4ABI,
-          functionName: "balanceOf",
-          args: [address],
-          chainId,
-        });
-
-        if (!balance || balance === 0n) {
-          return [];
-        }
-
-        // Fetch all token IDs in parallel
-        const tokenPromises: Promise<MultiChainNFTToken | null>[] = [];
-        for (let i = 0; i < Number(balance); i++) {
-          tokenPromises.push(
-            (async () => {
-              try {
-                const tokenId = await readContract(config, {
-                  address: contractAddress,
-                  abi: GenImNFTv4ABI,
-                  functionName: "tokenOfOwnerByIndex",
-                  args: [address, BigInt(i)],
-                  chainId,
-                });
-                return { tokenId: tokenId, network };
-              } catch (err) {
-                console.error(`Error fetching token at index ${i} on ${network}:`, err);
-                return null;
-              }
-            })(),
-          );
-        }
-
-        const results = await Promise.all(tokenPromises);
-        return results.filter((t): t is MultiChainNFTToken => t !== null);
-      } catch (err) {
-        console.error(`Error fetching NFTs on ${network}:`, err);
-        return [];
-      }
-    },
-    [address],
-  );
-
-  /**
-   * Fetch NFTs from all networks in parallel
-   */
-  const loadAllNetworks = useCallback(async () => {
-    if (!isConnected || !address) {
-      setTokens([]);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // Fetch from all networks in parallel
-      const networkResults = await Promise.all(networks.map((network) => fetchUserTokensOnNetwork(network)));
-
-      // Flatten and sort by tokenId (descending - newest first)
-      const allTokens = networkResults.flat().sort((a, b) => {
-        if (b.tokenId > a.tokenId) return 1;
-        if (b.tokenId < a.tokenId) return -1;
-        return 0;
-      });
-
-      setTokens(allTokens);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to load NFTs";
-      setError(message);
-      console.error("Error loading multi-chain NFTs:", err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isConnected, address, networks, fetchUserTokensOnNetwork]);
-
-  // Async fetch drives state updates — no synchronous alternative for remote data.
-
-  useEffect(() => {
-    if (isConnected && address) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      void loadAllNetworks();
-    }
-  }, [isConnected, address, loadAllNetworks]);
+  const {
+    data: tokens = [],
+    isPending,
+    isError,
+    error: queryError,
+    refetch,
+  } = useQuery({
+    queryKey: ["multiChainUserNFTs", address, networks.join(",")],
+    queryFn: () => fetchAllUserNFTs(networks, address!),
+    enabled: isConnected && !!address,
+  });
 
   return {
     tokens,
-    isLoading,
-    error,
-    reload: loadAllNetworks,
+    isLoading: isPending && isConnected && !!address,
+    error: isError ? (queryError instanceof Error ? queryError.message : "Failed to load NFTs") : null,
+    reload: async () => {
+      await refetch();
+    },
   };
 }
 
-/**
- * Options for the useMultiChainPublicNFTs hook
- */
 interface UseMultiChainPublicNFTsOptions {
-  /** Include testnet NFTs (default: false) */
   includeTestnets?: boolean;
 }
 
-/**
- * Result of the useMultiChainPublicNFTs hook
- */
 interface UseMultiChainPublicNFTsResult {
-  /** All public NFT tokens across chains (sorted by tokenId descending) */
   tokens: MultiChainNFTToken[];
-  /** Loading state */
   isLoading: boolean;
-  /** Error message if any */
   error: string | null;
-  /** Reload all chains */
   reload: () => Promise<void>;
 }
 
-/**
- * Hook to fetch public (listed) NFTs across all configured chains in parallel.
- */
+async function fetchPublicTokensOnNetwork(network: string): Promise<MultiChainNFTToken[]> {
+  const contractAddress = getGenAiNFTAddress(network);
+  const chainId = fromCAIP2(network);
+
+  const tokenIds = (await readContract(config, {
+    address: contractAddress,
+    abi: GenImNFTv4ABI,
+    functionName: "getAllPublicTokens",
+    chainId,
+  })) as bigint[];
+
+  if (!tokenIds || tokenIds.length === 0) return [];
+  return tokenIds.map((tokenId) => ({ tokenId, network }));
+}
+
+async function fetchAllPublicNFTs(networks: string[]): Promise<MultiChainNFTToken[]> {
+  const networkResults = await Promise.all(
+    networks.map((network) => fetchPublicTokensOnNetwork(network).catch(() => [] as MultiChainNFTToken[])),
+  );
+  return networkResults.flat().sort((a, b) => (b.tokenId > a.tokenId ? 1 : b.tokenId < a.tokenId ? -1 : 0));
+}
+
 export function useMultiChainPublicNFTs(options: UseMultiChainPublicNFTsOptions = {}): UseMultiChainPublicNFTsResult {
   const { includeTestnets = false } = options;
 
-  const [tokens, setTokens] = useState<MultiChainNFTToken[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const networks = useMemo(() => GENAI_NFT_NETWORKS.filter((n) => includeTestnets || !isTestnet(n)), [includeTestnets]);
 
-  // Filter networks based on testnet preference
-  const networks = useMemo(() => {
-    return GENAI_NFT_NETWORKS.filter((n) => includeTestnets || !isTestnet(n));
-  }, [includeTestnets]);
-
-  /**
-   * Fetch all public token IDs on a single network
-   */
-  const fetchPublicTokensOnNetwork = useCallback(async (network: string): Promise<MultiChainNFTToken[]> => {
-    const contractAddress = getGenAiNFTAddress(network);
-    const chainId = fromCAIP2(network);
-
-    try {
-      const tokenIds = (await readContract(config, {
-        address: contractAddress,
-        abi: GenImNFTv4ABI,
-        functionName: "getAllPublicTokens",
-        chainId,
-      })) as bigint[];
-
-      if (!tokenIds || tokenIds.length === 0) {
-        return [];
-      }
-
-      return tokenIds.map((tokenId) => ({ tokenId, network }));
-    } catch (err) {
-      console.error(`Error fetching public NFTs on ${network}:`, err);
-      return [];
-    }
-  }, []);
-
-  /**
-   * Fetch public NFTs from all networks in parallel
-   */
-  const loadAllNetworks = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // Fetch from all networks in parallel
-      const networkResults = await Promise.all(networks.map((network) => fetchPublicTokensOnNetwork(network)));
-
-      // Flatten and sort by tokenId (descending - newest first)
-      const allTokens = networkResults.flat().sort((a, b) => {
-        if (b.tokenId > a.tokenId) return 1;
-        if (b.tokenId < a.tokenId) return -1;
-        return 0;
-      });
-
-      setTokens(allTokens);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to load public NFTs";
-      setError(message);
-      console.error("Error loading multi-chain public NFTs:", err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [networks, fetchPublicTokensOnNetwork]);
-
-  // Async fetch drives state updates — no synchronous alternative for remote data.
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void loadAllNetworks();
-  }, [loadAllNetworks]);
+  const {
+    data: tokens = [],
+    isPending,
+    isError,
+    error: queryError,
+    refetch,
+  } = useQuery({
+    queryKey: ["multiChainPublicNFTs", networks.join(",")],
+    queryFn: () => fetchAllPublicNFTs(networks),
+  });
 
   return {
     tokens,
-    isLoading,
-    error,
-    reload: loadAllNetworks,
+    isLoading: isPending,
+    error: isError ? (queryError instanceof Error ? queryError.message : "Failed to load public NFTs") : null,
+    reload: async () => {
+      await refetch();
+    },
   };
 }

--- a/website/hooks/useNFTListedStatus.ts
+++ b/website/hooks/useNFTListedStatus.ts
@@ -11,7 +11,7 @@ export interface UseNFTListedStatusOptions {
 }
 
 export interface UseNFTListedStatusResult {
-  isListed: boolean | undefined;
+  isListed: boolean | null | undefined;
   isLoading: boolean;
   error: string | undefined;
   refetch: () => Promise<void>;
@@ -35,7 +35,7 @@ export function useNFTListedStatus({
     isError,
     error: queryError,
     refetch,
-  } = useQuery<boolean | undefined>({
+  } = useQuery<boolean | null>({
     queryKey,
     queryFn: async () => {
       try {
@@ -53,7 +53,7 @@ export function useNFTListedStatus({
           (err.message.includes("reverted") ||
             err.name.includes("ContractFunctionRevertedError") ||
             err.name.includes("ContractFunctionExecutionError"));
-        if (isContractRevert) return undefined;
+        if (isContractRevert) return null;
         throw err;
       }
     },
@@ -70,7 +70,7 @@ export function useNFTListedStatus({
 
   return {
     isListed,
-    isLoading: isPending,
+    isLoading: enabled !== false && isPending,
     error: isError ? (queryError instanceof Error ? queryError.message : "Failed to load listing status") : undefined,
     refetch: async () => {
       await refetch();

--- a/website/hooks/useNFTListedStatus.ts
+++ b/website/hooks/useNFTListedStatus.ts
@@ -1,124 +1,80 @@
-/**
- * Hook to fetch and manage the listing status of an NFT.
- *
- * This hook encapsulates the logic for checking if an NFT is publicly listed
- * via the smart contract's isTokenListed function.
- *
- * @example
- * ```tsx
- * const { isListed, isLoading, error, refetch } = useNFTListedStatus({
- *   tokenId: BigInt(42),
- *   network: "eip155:10",
- *   enabled: !isPublicView, // Only fetch in private view
- * });
- * ```
- */
-
-import { useState, useEffect, useCallback } from "react";
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { readContract } from "wagmi/actions";
 import { config } from "../wagmi.config";
 import { getGenAiNFTAddress, GenImNFTv4ABI, fromCAIP2 } from "@fretchen/chain-utils";
 
 export interface UseNFTListedStatusOptions {
-  /** The token ID to check */
   tokenId: bigint;
-  /** The CAIP-2 network string (e.g., "eip155:10") */
   network: string;
-  /** Whether to enable the query (default: true) */
   enabled?: boolean;
 }
 
 export interface UseNFTListedStatusResult {
-  /** Whether the NFT is listed (undefined if not yet loaded) */
   isListed: boolean | undefined;
-  /** Whether the query is currently loading */
   isLoading: boolean;
-  /** Error message if the query failed */
   error: string | undefined;
-  /** Function to manually refetch the listing status */
   refetch: () => Promise<void>;
-  /** Optimistically update the listing status (for UI feedback) */
   setOptimisticListed: (value: boolean) => void;
 }
 
-/**
- * Fetches and manages the listing status of an NFT from the smart contract.
- *
- * The isListed status determines whether an NFT appears in the public gallery.
- * This hook only fetches in private view (when enabled=true).
- */
 export function useNFTListedStatus({
   tokenId,
   network,
   enabled = true,
 }: UseNFTListedStatusOptions): UseNFTListedStatusResult {
-  const [isListed, setIsListed] = useState<boolean | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | undefined>(undefined);
-
+  const queryClient = useQueryClient();
   const chainId = fromCAIP2(network);
   const contractAddress = getGenAiNFTAddress(network);
+  const tokenIdStr = tokenId.toString();
+  const queryKey = ["nftListedStatus", tokenIdStr, network] as const;
 
-  const fetchListedStatus = useCallback(async () => {
-    if (!enabled) {
-      // Don't reset isListed when disabled - keep the last known value
-      // This prevents flickering when enabled toggles temporarily
-      return;
-    }
-
-    setIsLoading(true);
-    setError(undefined);
-
-    try {
-      const result = await readContract(config, {
-        address: contractAddress,
-        abi: GenImNFTv4ABI,
-        functionName: "isTokenListed",
-        args: [tokenId],
-        chainId,
-      });
-
-      setIsListed(result);
-    } catch (err) {
-      // Distinguish between contract reverts (legacy tokens) and real errors
-      const isContractRevert =
-        err instanceof Error &&
-        (err.message.includes("reverted") ||
-          err.name.includes("ContractFunctionRevertedError") ||
-          err.name.includes("ContractFunctionExecutionError"));
-
-      if (isContractRevert) {
-        // Legacy tokens minted before isListed feature - not an error, just not supported
-        // Keep isListed as undefined - UI will hide the toggle for these tokens
-        setError("isListed not available for this token");
-      } else {
-        // Real errors (network issues, etc.) - log and set error
-        console.error("Failed to load listing status:", err);
-        setError(err instanceof Error ? err.message : "Failed to load listing status");
+  const {
+    data: isListed,
+    isPending,
+    isError,
+    error: queryError,
+    refetch,
+  } = useQuery<boolean | undefined>({
+    queryKey,
+    queryFn: async () => {
+      try {
+        return await readContract(config, {
+          address: contractAddress,
+          abi: GenImNFTv4ABI,
+          functionName: "isTokenListed",
+          args: [tokenId],
+          chainId,
+        });
+      } catch (err) {
+        // Legacy tokens minted before isListed feature — not a real error
+        const isContractRevert =
+          err instanceof Error &&
+          (err.message.includes("reverted") ||
+            err.name.includes("ContractFunctionRevertedError") ||
+            err.name.includes("ContractFunctionExecutionError"));
+        if (isContractRevert) return undefined;
+        throw err;
       }
-      // In both cases, isListed remains undefined
-    } finally {
-      setIsLoading(false);
-    }
-  }, [tokenId, enabled, contractAddress, chainId]);
+    },
+    enabled,
+  });
 
-  // Async fetch drives state updates — no synchronous alternative for remote data.
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void fetchListedStatus();
-  }, [fetchListedStatus]);
-
-  // Optimistic update for immediate UI feedback
-  const setOptimisticListed = useCallback((value: boolean) => {
-    setIsListed(value);
-  }, []);
+  const setOptimisticListed = useCallback(
+    (value: boolean) => {
+      queryClient.setQueryData(queryKey, value);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [queryClient, tokenIdStr, network],
+  );
 
   return {
     isListed,
-    isLoading,
-    error,
-    refetch: fetchListedStatus,
+    isLoading: isPending,
+    error: isError ? (queryError instanceof Error ? queryError.message : "Failed to load listing status") : undefined,
+    refetch: async () => {
+      await refetch();
+    },
     setOptimisticListed,
   };
 }

--- a/website/pages/+config.ts
+++ b/website/pages/+config.ts
@@ -15,4 +15,14 @@ export default {
   description: "Blog, notepad, whatever you want to call it.",
   prerender: true,
   extends: [vikeReact, vikeReactQuery],
+
+  queryClientConfig: {
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  },
 } satisfies Config;

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -603,6 +603,13 @@ export default function Page() {
     await updateMutation.mutateAsync({ id, body });
   };
 
+  const handleTabChange = (newTab: Tab) => {
+    setTab(newTab);
+    approveMutation.reset();
+    rejectMutation.reset();
+    updateMutation.reset();
+  };
+
   // Pre-hydration: show nothing interactive
   if (!hasMounted) {
     return (
@@ -666,7 +673,11 @@ export default function Page() {
         <>
           <div className={tabBar}>
             {tabs.map((t) => (
-              <button key={t.key} className={tab === t.key ? tabButtonActive : tabButton} onClick={() => setTab(t.key)}>
+              <button
+                key={t.key}
+                className={tab === t.key ? tabButtonActive : tabButton}
+                onClick={() => handleTabChange(t.key)}
+              >
                 {t.label} ({t.count})
               </button>
             ))}

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -1,9 +1,15 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import { useIsMounted } from "../../hooks/useIsMounted";
 import { useAccount, useConnect } from "wagmi";
 import { css } from "../../styled-system/css";
-import { useGrowthApi } from "../../hooks/useGrowthApi";
-import { CHANNEL_CHAR_LIMITS, type ContentQueue, type Draft, type Insights } from "../../types/growth";
+import {
+  useGrowthDrafts,
+  useGrowthInsights,
+  useApproveDraft,
+  useRejectDraft,
+  useUpdateDraft,
+} from "../../hooks/useGrowthApi";
+import { CHANNEL_CHAR_LIMITS, type Draft, type Insights } from "../../types/growth";
 import { OWNER_ADDRESS } from "../../utils/getChain";
 
 type Tab = "drafts" | "approved" | "published" | "rejected";
@@ -551,41 +557,26 @@ export default function Page() {
 
   const { address, status } = useAccount();
   const { connectors, connect } = useConnect();
-  const { fetchDrafts, fetchInsights, updateDraft, approveDraft: apiApprove, rejectDraft: apiReject } = useGrowthApi();
 
-  const [queue, setQueue] = useState<ContentQueue | null>(null);
-  const [insights, setInsights] = useState<Insights | null>(null);
   const [tab, setTab] = useState<Tab>("drafts");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
 
   // Use status === "connected" (not just isConnected) to ensure wagmi's
   // reconnect is fully complete before we call signMessageAsync.
   const isOwner = hasMounted && status === "connected" && address?.toLowerCase() === OWNER_ADDRESS.toLowerCase();
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [q, ins] = await Promise.all([fetchDrafts(), fetchInsights()]);
-      setQueue(q);
-      setInsights(ins);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load data");
-    } finally {
-      setLoading(false);
-    }
-  }, [fetchDrafts, fetchInsights]);
+  const { data: queue, isPending: loadingDrafts, error: draftsError } = useGrowthDrafts(isOwner);
+  const { data: insights } = useGrowthInsights(isOwner);
 
-  // Async fetch drives state updates — no synchronous alternative for remote data.
+  const approveMutation = useApproveDraft();
+  const rejectMutation = useRejectDraft();
+  const updateMutation = useUpdateDraft();
 
-  useEffect(() => {
-    if (isOwner) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      void loadData();
-    }
-  }, [isOwner, loadData]);
+  const busy = approveMutation.isPending || rejectMutation.isPending || updateMutation.isPending;
+  const error =
+    (draftsError instanceof Error ? draftsError.message : draftsError ? "Failed to load drafts" : null) ??
+    (approveMutation.error instanceof Error ? approveMutation.error.message : null) ??
+    (rejectMutation.error instanceof Error ? rejectMutation.error.message : null) ??
+    (updateMutation.error instanceof Error ? updateMutation.error.message : null);
 
   const historyByPage = useMemo(() => {
     const map: Record<string, Draft[]> = {};
@@ -601,74 +592,15 @@ export default function Page() {
   }, [queue?.published]);
 
   const handleApprove = async (id: string, scheduledAt?: string, reviewComment?: string) => {
-    setBusy(true);
-    setError(null);
-    try {
-      const response = await apiApprove(id, scheduledAt, reviewComment);
-      // Optimistic update
-      setQueue((prev) => {
-        if (!prev) return prev;
-        const draft = prev.drafts.find((d) => d.id === id);
-        if (!draft) return prev;
-        const updated = { ...draft, ...response };
-        return {
-          ...prev,
-          drafts: prev.drafts.filter((d) => d.id !== id),
-          approved: [...prev.approved, updated],
-        };
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to approve");
-    } finally {
-      setBusy(false);
-    }
+    await approveMutation.mutateAsync({ id, scheduledAt, reviewComment });
   };
 
   const handleReject = async (id: string, reviewComment?: string) => {
-    setBusy(true);
-    setError(null);
-    try {
-      const response = await apiReject(id, reviewComment);
-      // Optimistic update
-      setQueue((prev) => {
-        if (!prev) return prev;
-        const draft = prev.drafts.find((d) => d.id === id) || prev.approved.find((d) => d.id === id);
-        if (!draft) return prev;
-        const updated = { ...draft, ...response };
-        return {
-          ...prev,
-          drafts: prev.drafts.filter((d) => d.id !== id),
-          approved: prev.approved.filter((d) => d.id !== id),
-          rejected: [...prev.rejected, updated],
-        };
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to reject");
-    } finally {
-      setBusy(false);
-    }
+    await rejectMutation.mutateAsync({ id, reviewComment });
   };
 
   const handleUpdate = async (id: string, body: Partial<Draft>) => {
-    setBusy(true);
-    setError(null);
-    try {
-      const updated = await updateDraft(id, body);
-      // Update in-place
-      setQueue((prev) => {
-        if (!prev) return prev;
-        const updateIn = (list: Draft[]) => list.map((d) => (d.id === id ? { ...d, ...updated } : d));
-        return {
-          ...prev,
-          drafts: updateIn(prev.drafts),
-          approved: updateIn(prev.approved),
-        };
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update");
-    } finally {
-      setBusy(false);
-    }
+    await updateMutation.mutateAsync({ id, body });
   };
 
   // Pre-hydration: show nothing interactive
@@ -728,7 +660,7 @@ export default function Page() {
 
       {error && <div className={errorBanner}>{error}</div>}
 
-      {loading ? (
+      {loadingDrafts ? (
         <p className={loadingText}>Loading drafts...</p>
       ) : (
         <>
@@ -757,7 +689,7 @@ export default function Page() {
             ))
           )}
 
-          <InsightsSection insights={insights} />
+          <InsightsSection insights={insights ?? null} />
         </>
       )}
     </div>

--- a/website/test/CommentsSection.test.tsx
+++ b/website/test/CommentsSection.test.tsx
@@ -128,14 +128,15 @@ describe("CommentsSection Component", () => {
   });
 
   describe("Fetch Error Handling", () => {
-    it("should handle fetch errors gracefully", async () => {
+    it("should show an error message when comments cannot be loaded", async () => {
       (global.fetch as Mock).mockRejectedValueOnce(new Error("Network error"));
 
       renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
-        expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
+        expect(screen.getByText(/Could not load comments/i)).toBeInTheDocument();
       });
+      expect(screen.queryByText(/No comments yet/i)).not.toBeInTheDocument();
     });
   });
 

--- a/website/test/CommentsSection.test.tsx
+++ b/website/test/CommentsSection.test.tsx
@@ -128,8 +128,23 @@ describe("CommentsSection Component", () => {
   });
 
   describe("Fetch Error Handling", () => {
-    it("should show an error message when comments cannot be loaded", async () => {
+    it("should show an error message on network failure", async () => {
       (global.fetch as Mock).mockRejectedValueOnce(new Error("Network error"));
+
+      renderWithQuery(<CommentsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Could not load comments/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/No comments yet/i)).not.toBeInTheDocument();
+    });
+
+    it("should show an error message on server error (non-ok response)", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      });
 
       renderWithQuery(<CommentsSection />);
 

--- a/website/test/CommentsSection.test.tsx
+++ b/website/test/CommentsSection.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import React from "react";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { CommentsSection } from "../components/CommentsSection";
+import { renderWithQuery } from "./testUtils";
 
 // Mock vike-react/usePageContext
 vi.mock("vike-react/usePageContext", () => ({
@@ -31,7 +32,7 @@ describe("CommentsSection Component", () => {
           }),
       );
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       expect(screen.getByText(/Loading comments/i)).toBeInTheDocument();
     });
@@ -44,7 +45,7 @@ describe("CommentsSection Component", () => {
         json: async () => ({ comments: [] }),
       });
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -76,7 +77,7 @@ describe("CommentsSection Component", () => {
         json: async () => mockComments,
       });
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText("Great post!")).toBeInTheDocument();
@@ -103,7 +104,7 @@ describe("CommentsSection Component", () => {
         }),
       });
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText("Buy stuff")).toBeInTheDocument();
@@ -118,7 +119,7 @@ describe("CommentsSection Component", () => {
         json: async () => ({ comments: [] }),
       });
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("page=%2Fquantum%2Famo%2F0"));
@@ -130,7 +131,7 @@ describe("CommentsSection Component", () => {
     it("should handle fetch errors gracefully", async () => {
       (global.fetch as Mock).mockRejectedValueOnce(new Error("Network error"));
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -148,7 +149,7 @@ describe("CommentsSection Component", () => {
     });
 
     it("should render the comment form immediately (always visible)", async () => {
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -160,7 +161,7 @@ describe("CommentsSection Component", () => {
     });
 
     it("should submit a comment successfully", async () => {
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -197,7 +198,7 @@ describe("CommentsSection Component", () => {
     });
 
     it("should show error message on submission failure", async () => {
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -220,7 +221,7 @@ describe("CommentsSection Component", () => {
     });
 
     it("should not submit when text is empty", async () => {
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -231,7 +232,7 @@ describe("CommentsSection Component", () => {
     });
 
     it("should have a hidden honeypot field", async () => {
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();
@@ -251,7 +252,7 @@ describe("CommentsSection Component", () => {
         json: async () => ({ comments: [] }),
       });
 
-      render(<CommentsSection />);
+      renderWithQuery(<CommentsSection />);
 
       await waitFor(() => {
         expect(screen.getByText(/No comments yet/i)).toBeInTheDocument();

--- a/website/test/GrowthPage.test.tsx
+++ b/website/test/GrowthPage.test.tsx
@@ -4,22 +4,19 @@ import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/re
 import { useAccount, useConnect } from "wagmi";
 import { OWNER_ADDRESS } from "../utils/getChain";
 
-// Mock useGrowthApi
-const mockFetchDrafts = vi.fn();
-const mockFetchInsights = vi.fn();
-const mockApproveDraft = vi.fn();
-const mockRejectDraft = vi.fn();
-const mockUpdateDraft = vi.fn();
+// Mock the new TQ-based growth hooks
+const mockUseGrowthDrafts = vi.fn();
+const mockUseGrowthInsights = vi.fn();
+const mockApproveMutateAsync = vi.fn();
+const mockRejectMutateAsync = vi.fn();
+const mockUpdateMutateAsync = vi.fn();
 
 vi.mock("../hooks/useGrowthApi", () => ({
-  useGrowthApi: () => ({
-    fetchDrafts: mockFetchDrafts,
-    fetchInsights: mockFetchInsights,
-    fetchPerformance: vi.fn().mockResolvedValue({ posts: [] }),
-    approveDraft: mockApproveDraft,
-    rejectDraft: mockRejectDraft,
-    updateDraft: mockUpdateDraft,
-  }),
+  useGrowthDrafts: (...args: unknown[]) => mockUseGrowthDrafts(...args),
+  useGrowthInsights: (...args: unknown[]) => mockUseGrowthInsights(...args),
+  useApproveDraft: () => ({ mutateAsync: mockApproveMutateAsync, isPending: false, error: null }),
+  useRejectDraft: () => ({ mutateAsync: mockRejectMutateAsync, isPending: false, error: null }),
+  useUpdateDraft: () => ({ mutateAsync: mockUpdateMutateAsync, isPending: false, error: null }),
 }));
 
 // Mock styled-system
@@ -52,16 +49,15 @@ const sampleQueue = {
 describe("Growth Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetchDrafts.mockResolvedValue(sampleQueue);
-    mockFetchInsights.mockResolvedValue({
-      growth_opportunities: [],
-      last_analysis: null,
-      social_metrics: {},
-      website_analytics: {},
+    mockUseGrowthDrafts.mockReturnValue({ data: sampleQueue, isPending: false, error: null });
+    mockUseGrowthInsights.mockReturnValue({
+      data: { growth_opportunities: [], last_analysis: null, social_metrics: {}, website_analytics: {} },
+      isPending: false,
+      error: null,
     });
-    mockApproveDraft.mockResolvedValue({ ...sampleQueue.drafts[0], status: "approved" });
-    mockRejectDraft.mockResolvedValue({ ...sampleQueue.drafts[0], status: "rejected" });
-    mockUpdateDraft.mockResolvedValue({ ...sampleQueue.drafts[0], content: "Updated content" });
+    mockApproveMutateAsync.mockResolvedValue({ ...sampleQueue.drafts[0], status: "approved" });
+    mockRejectMutateAsync.mockResolvedValue({ ...sampleQueue.drafts[0], status: "rejected" });
+    mockUpdateMutateAsync.mockResolvedValue({ ...sampleQueue.drafts[0], content: "Updated content" });
   });
 
   afterEach(() => {
@@ -104,10 +100,6 @@ describe("Growth Page", () => {
     } as ReturnType<typeof useAccount>);
 
     render(<Page />);
-
-    await waitFor(() => {
-      expect(mockFetchDrafts).toHaveBeenCalled();
-    });
 
     await waitFor(() => {
       expect(screen.getByText("Check out this blog post about game theory!")).toBeInTheDocument();
@@ -159,7 +151,11 @@ describe("Growth Page", () => {
     fireEvent.click(screen.getByText("Confirm Approve"));
 
     await waitFor(() => {
-      expect(mockApproveDraft).toHaveBeenCalledWith("draft_1", undefined, undefined);
+      expect(mockApproveMutateAsync).toHaveBeenCalledWith({
+        id: "draft_1",
+        scheduledAt: undefined,
+        reviewComment: undefined,
+      });
     });
   });
 
@@ -179,7 +175,7 @@ describe("Growth Page", () => {
     fireEvent.click(screen.getByText("Reject"));
 
     await waitFor(() => {
-      expect(mockRejectDraft).toHaveBeenCalledWith("draft_1", undefined);
+      expect(mockRejectMutateAsync).toHaveBeenCalledWith({ id: "draft_1", reviewComment: undefined });
     });
   });
 
@@ -204,7 +200,7 @@ describe("Growth Page", () => {
   });
 
   it("shows error banner when API call fails", async () => {
-    mockFetchDrafts.mockRejectedValueOnce(new Error("Network error"));
+    mockUseGrowthDrafts.mockReturnValue({ data: undefined, isPending: false, error: new Error("Network error") });
 
     vi.mocked(useAccount).mockReturnValue({
       address: OWNER_ADDRESS,
@@ -240,9 +236,10 @@ describe("Growth Page", () => {
 
   it("disables save button when content exceeds character limit", async () => {
     const longContent = "x".repeat(501);
-    mockFetchDrafts.mockResolvedValue({
-      ...sampleQueue,
-      drafts: [{ ...sampleQueue.drafts[0], content: longContent }],
+    mockUseGrowthDrafts.mockReturnValue({
+      data: { ...sampleQueue, drafts: [{ ...sampleQueue.drafts[0], content: longContent }] },
+      isPending: false,
+      error: null,
     });
 
     vi.mocked(useAccount).mockReturnValue({
@@ -265,9 +262,10 @@ describe("Growth Page", () => {
 
   it("shows over-limit warning and disables approve for too-long content", async () => {
     const longContent = "y".repeat(501);
-    mockFetchDrafts.mockResolvedValue({
-      ...sampleQueue,
-      drafts: [{ ...sampleQueue.drafts[0], content: longContent }],
+    mockUseGrowthDrafts.mockReturnValue({
+      data: { ...sampleQueue, drafts: [{ ...sampleQueue.drafts[0], content: longContent }] },
+      isPending: false,
+      error: null,
     });
 
     vi.mocked(useAccount).mockReturnValue({

--- a/website/test/GrowthPage.test.tsx
+++ b/website/test/GrowthPage.test.tsx
@@ -330,7 +330,10 @@ describe("Growth Page", () => {
   });
 
   it("clears approve error banner after switching tabs", async () => {
-    // Simulate a mutation error being present
+    // mockApproveError is read by the vi.mock closure at call time (not creation time),
+    // so updating it here affects what the mock returns on next render.
+    // Setting it to null before rerender simulates what reset() does in production.
+    // The "calls reset on all mutations" test above verifies reset() is actually invoked.
     mockApproveError = new Error("Approve failed");
 
     vi.mocked(useAccount).mockReturnValue({

--- a/website/test/GrowthPage.test.tsx
+++ b/website/test/GrowthPage.test.tsx
@@ -10,13 +10,23 @@ const mockUseGrowthInsights = vi.fn();
 const mockApproveMutateAsync = vi.fn();
 const mockRejectMutateAsync = vi.fn();
 const mockUpdateMutateAsync = vi.fn();
+const mockApproveReset = vi.fn();
+const mockRejectReset = vi.fn();
+const mockUpdateReset = vi.fn();
+// Mutable error state for approve mutation (used in tab-switch test)
+let mockApproveError: Error | null = null;
 
 vi.mock("../hooks/useGrowthApi", () => ({
   useGrowthDrafts: (...args: unknown[]) => mockUseGrowthDrafts(...args),
   useGrowthInsights: (...args: unknown[]) => mockUseGrowthInsights(...args),
-  useApproveDraft: () => ({ mutateAsync: mockApproveMutateAsync, isPending: false, error: null }),
-  useRejectDraft: () => ({ mutateAsync: mockRejectMutateAsync, isPending: false, error: null }),
-  useUpdateDraft: () => ({ mutateAsync: mockUpdateMutateAsync, isPending: false, error: null }),
+  useApproveDraft: () => ({
+    mutateAsync: mockApproveMutateAsync,
+    isPending: false,
+    error: mockApproveError,
+    reset: mockApproveReset,
+  }),
+  useRejectDraft: () => ({ mutateAsync: mockRejectMutateAsync, isPending: false, error: null, reset: mockRejectReset }),
+  useUpdateDraft: () => ({ mutateAsync: mockUpdateMutateAsync, isPending: false, error: null, reset: mockUpdateReset }),
 }));
 
 // Mock styled-system
@@ -49,6 +59,7 @@ const sampleQueue = {
 describe("Growth Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApproveError = null; // reset mutable error state
     mockUseGrowthDrafts.mockReturnValue({ data: sampleQueue, isPending: false, error: null });
     mockUseGrowthInsights.mockReturnValue({
       data: { growth_opportunities: [], last_analysis: null, social_metrics: {}, website_analytics: {} },
@@ -295,6 +306,52 @@ describe("Growth Page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("43/500 characters")).toBeInTheDocument();
+    });
+  });
+
+  it("calls reset on all mutations when switching tabs", async () => {
+    vi.mocked(useAccount).mockReturnValue({
+      address: OWNER_ADDRESS,
+      isConnected: true,
+      status: "connected",
+    } as ReturnType<typeof useAccount>);
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Approved/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Approved/));
+
+    expect(mockApproveReset).toHaveBeenCalledOnce();
+    expect(mockRejectReset).toHaveBeenCalledOnce();
+    expect(mockUpdateReset).toHaveBeenCalledOnce();
+  });
+
+  it("clears approve error banner after switching tabs", async () => {
+    // Simulate a mutation error being present
+    mockApproveError = new Error("Approve failed");
+
+    vi.mocked(useAccount).mockReturnValue({
+      address: OWNER_ADDRESS,
+      isConnected: true,
+      status: "connected",
+    } as ReturnType<typeof useAccount>);
+
+    const { rerender } = render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Approve failed")).toBeInTheDocument();
+    });
+
+    // Clicking a tab calls reset() — simulate the effect by clearing the error
+    mockApproveError = null;
+    fireEvent.click(screen.getByText(/Approved/));
+    rerender(<Page />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Approve failed")).not.toBeInTheDocument();
     });
   });
 });

--- a/website/test/ImageGenerator.fileUpload.test.tsx
+++ b/website/test/ImageGenerator.fileUpload.test.tsx
@@ -13,7 +13,8 @@
 
 import React from "react";
 import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithQuery } from "./testUtils";
 import { ImageGenerator } from "../components/ImageGenerator";
 import { useAccount, useWalletClient } from "wagmi";
 
@@ -50,7 +51,7 @@ describe("ImageGenerator Reference Image Integration", () => {
 
   describe("🔴 HOCH: Basic Component Integration", () => {
     it("sollte ImageGenerator Component rendern können", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // LocaleText zeigt echte übersetzte Texte, useLocale gibt Label-Keys zurück
       expect(screen.getByText("Create Collectible AI Art • 10¢")).toBeInTheDocument();
@@ -59,7 +60,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte File Input korrekt konfiguriert haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const fileInput = screen.getByTestId("reference-image-input");
       expect(fileInput).toBeInTheDocument();
@@ -68,7 +69,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Drop Zone haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const dropZone = screen.getByTestId("drop-zone");
       expect(dropZone).toBeInTheDocument();
@@ -77,7 +78,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte verschiedene Image Sizes unterstützen", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const sizeSelect = screen.getByLabelText("Select image format for your artwork");
       expect(sizeSelect).toBeInTheDocument();
@@ -90,7 +91,7 @@ describe("ImageGenerator Reference Image Integration", () => {
 
   describe("🔴 HOCH: File Upload Functionality", () => {
     it("sollte JPEG Dateien akzeptieren", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const fileInput = screen.getByTestId("reference-image-input");
 
@@ -105,7 +106,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte PNG Dateien akzeptieren", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const fileInput = screen.getByTestId("reference-image-input");
 
@@ -120,7 +121,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Drag & Drop Zone haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const dropZone = screen.getByTestId("drop-zone");
       expect(dropZone).toBeInTheDocument();
@@ -132,7 +133,7 @@ describe("ImageGenerator Reference Image Integration", () => {
 
   describe("🔴 HOCH: UI State Management", () => {
     it("sollte initial Create Artwork Button zeigen", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // useLocale Mock gibt Label-Keys zurück
       const button = screen.getByRole("button", { name: /imagegen.enterPrompt/ });
@@ -140,7 +141,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Textarea für Prompt haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const textarea = screen.getByPlaceholderText("imagegen.promptPlaceholder");
       expect(textarea).toBeInTheDocument();
@@ -148,7 +149,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Listed Checkbox haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const checkbox = screen.getByRole("checkbox", { name: /Listed/ });
       expect(checkbox).toBeInTheDocument();
@@ -156,7 +157,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Image Size Select haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       const sizeSelect = screen.getByLabelText("Select image format for your artwork");
       expect(sizeSelect).toBeInTheDocument();
@@ -170,7 +171,7 @@ describe("ImageGenerator Reference Image Integration", () => {
 
   describe("🟢 HOCH: Dynamic Placeholder Tests", () => {
     it("sollte Standard-Placeholder zeigen wenn kein Reference Image hochgeladen ist", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // useLocale Mock gibt Label-Keys zurück
       const textarea = screen.getByPlaceholderText("imagegen.promptPlaceholder");
@@ -181,7 +182,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Button Text korrekt ändern basierend auf previewState", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // useLocale Mock gibt Label-Keys zurück
       const button = screen.getByRole("button", { name: /imagegen.enterPrompt/ });
@@ -189,7 +190,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte Edit-Mode Locale Keys korrekt geladen haben", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // useLocale Mock gibt Label-Keys zurück
       const textarea = screen.getByPlaceholderText("imagegen.promptPlaceholder");
@@ -200,7 +201,7 @@ describe("ImageGenerator Reference Image Integration", () => {
     });
 
     it("sollte previewState System für UI-Changes nutzen", () => {
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // Teste dass das previewState System die UI beeinflusst
       // Drop Zone sollte sichtbar sein im "empty" state

--- a/website/test/ImageGenerator.test.tsx
+++ b/website/test/ImageGenerator.test.tsx
@@ -31,7 +31,8 @@
 
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithQuery } from "./testUtils";
 import { ImageGenerator } from "../components/ImageGenerator";
 import { useAccount, useConnect, useWalletClient } from "wagmi";
 
@@ -69,7 +70,7 @@ describe("ImageGenerator Component", () => {
         status: "disconnected",
       } as ReturnType<typeof useAccount>);
 
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // Check for collapsed state content
       expect(screen.getByText(/🎨.*mocked-imagegen\.title/)).toBeInTheDocument();
@@ -98,7 +99,7 @@ describe("ImageGenerator Component", () => {
         status: "disconnected",
       } as ReturnType<typeof useAccount>);
 
-      render(<ImageGenerator {...mockProps} />);
+      renderWithQuery(<ImageGenerator {...mockProps} />);
 
       // Should still show collapsed state
       expect(screen.getByText(/🎨.*mocked-imagegen\.title/)).toBeInTheDocument();
@@ -121,7 +122,7 @@ describe("ImageGenerator Component", () => {
         connectors: [{ id: "mockConnector", name: "Mock Wallet" }],
       } as unknown as ReturnType<typeof useConnect>);
 
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // Verify we start in collapsed state
       expect(screen.getByText(/mocked-imagegen\.collapsedDescription/)).toBeInTheDocument();
@@ -154,7 +155,7 @@ describe("ImageGenerator Component", () => {
         },
       } as ReturnType<typeof useWalletClient>);
 
-      render(<ImageGenerator />);
+      renderWithQuery(<ImageGenerator />);
 
       // Should show expanded form elements
       expect(screen.getByPlaceholderText("mocked-imagegen.promptPlaceholder")).toBeInTheDocument();

--- a/website/test/Post.integration.test.tsx
+++ b/website/test/Post.integration.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { renderWithQuery } from "./testUtils";
 import { Post } from "../components/Post";
 import React from "react";
 import "@testing-library/jest-dom";
@@ -67,7 +68,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act: Render the Post component
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Title should be rendered
       expect(screen.getByText("Hello World")).toBeInTheDocument();
@@ -90,7 +91,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Full title should be rendered
       expect(screen.getByText("Moving old lectures")).toBeInTheDocument();
@@ -111,7 +112,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Title and metadata
       expect(screen.getByText("A gallery of AI images")).toBeInTheDocument();
@@ -130,7 +131,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Title
       expect(screen.getByText("Merkle Ai Batching")).toBeInTheDocument();
@@ -150,7 +151,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Navigation should be present
       expect(screen.getByText(/Previous:/)).toBeInTheDocument();
@@ -169,7 +170,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Title renders but no navigation
       expect(screen.getByText("Standalone Post")).toBeInTheDocument();
@@ -190,7 +191,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Support button should be present (new text: "Support ~50¢")
       expect(screen.getByText(/Support/)).toBeInTheDocument();
@@ -209,7 +210,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Wait for fetch to be called
       await vi.waitFor(() => {
@@ -243,7 +244,7 @@ describe("Post Component Integration Tests", () => {
       };
 
       // Act
-      render(<Post {...postProps} />);
+      renderWithQuery(<Post {...postProps} />);
 
       // Assert: Webmentions API should be called
       await vi.waitFor(() => {

--- a/website/test/Webmentions.test.tsx
+++ b/website/test/Webmentions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithQuery } from "./testUtils";
 import { Webmentions } from "../components/Webmentions";
 
 /**
@@ -41,7 +42,7 @@ describe("Webmentions Component", () => {
           }),
       );
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       expect(screen.getByText(/Loading reactions/i)).toBeInTheDocument();
     });
@@ -54,7 +55,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText("Social Reactions")).toBeInTheDocument();
@@ -71,7 +72,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByRole("link", { name: /Bluesky/i })).toBeInTheDocument();
@@ -88,7 +89,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         // Should fetch from both URL variants
@@ -121,7 +122,7 @@ describe("Webmentions Component", () => {
           json: async () => ({ children: [duplicateMention] }),
         });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         // Should only show one like, not two (deduplicated)
@@ -135,7 +136,7 @@ describe("Webmentions Component", () => {
     it("should handle fetch errors gracefully", async () => {
       (global.fetch as Mock).mockRejectedValueOnce(new Error("Network error"));
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText("Social Reactions")).toBeInTheDocument();
@@ -175,7 +176,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/❤️ 2/)).toBeInTheDocument();
@@ -205,7 +206,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/❤️ 1/)).toBeInTheDocument();
@@ -226,7 +227,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.queryByText(/Likes/i)).not.toBeInTheDocument();
@@ -256,7 +257,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/🔁 1/)).toBeInTheDocument();
@@ -292,7 +293,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/🔁 3/)).toBeInTheDocument();
@@ -326,7 +327,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/💬 1/)).toBeInTheDocument();
@@ -360,7 +361,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText(/💬 1/)).toBeInTheDocument();
@@ -390,7 +391,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText("Frank")).toBeInTheDocument();
@@ -409,7 +410,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByRole("link", { name: /Bluesky/i })).toBeInTheDocument();
@@ -465,7 +466,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         expect(screen.getByText("Reactions")).toBeInTheDocument();
@@ -485,7 +486,7 @@ describe("Webmentions Component", () => {
         json: async () => ({ children: [] }),
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         const blueskyLink = screen.getByRole("link", { name: /Bluesky/i });
@@ -515,7 +516,7 @@ describe("Webmentions Component", () => {
         json: async () => mockData,
       });
 
-      render(<Webmentions />);
+      renderWithQuery(<Webmentions />);
 
       await waitFor(() => {
         const avatar = screen.getByAltText("Alice");

--- a/website/test/testUtils.tsx
+++ b/website/test/testUtils.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, renderHook, type RenderOptions, type RenderHookOptions } from "@testing-library/react";
+
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const [queryClient] = React.useState(() => createTestQueryClient());
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+export function renderWithQuery(ui: React.ReactElement, options?: Omit<RenderOptions, "wrapper">) {
+  return render(ui, { wrapper: Wrapper, ...options });
+}
+
+export function renderHookWithQuery<Result, Props>(
+  hook: (props: Props) => Result,
+  options?: Omit<RenderHookOptions<Props>, "wrapper">,
+) {
+  return renderHook(hook, { wrapper: Wrapper, ...options });
+}

--- a/website/test/useGrowthApi.test.ts
+++ b/website/test/useGrowthApi.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useAccount, useSignMessage } from "wagmi";
-import { useGrowthApi } from "../hooks/useGrowthApi";
+import { useGrowthApi, clearAuthCacheForTesting } from "../hooks/useGrowthApi";
 
 const OWNER_ADDRESS = "0xAAEBC1441323B8ad6Bdf6793A8428166b510239C";
 
@@ -10,6 +10,7 @@ describe("useGrowthApi", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearAuthCacheForTesting(); // isolate module-level cache between tests
     globalThis.fetch = vi.fn();
 
     vi.mocked(useAccount).mockReturnValue({
@@ -223,6 +224,37 @@ describe("useGrowthApi", () => {
       } as ReturnType<typeof useAccount>);
       rerender();
 
+      await result.current.fetchDrafts();
+      expect(mockSignMessageAsync).toHaveBeenCalledTimes(2);
+    });
+
+    it("shares token across separate hook instances (module-level cache)", async () => {
+      mockFetchResponse({ drafts: [], approved: [], published: [], rejected: [] });
+      mockFetchResponse({ drafts: [], approved: [], published: [], rejected: [] });
+
+      // Two independent renderHook calls simulate useGrowthDrafts + useApproveDraft
+      // being used together in a component — each creates its own React closure.
+      const { result: hook1 } = renderHook(() => useGrowthApi());
+      const { result: hook2 } = renderHook(() => useGrowthApi());
+
+      await hook1.current.fetchDrafts(); // signs and caches token
+      await hook2.current.fetchInsights(); // separate instance — should reuse cached token
+
+      expect(mockSignMessageAsync).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearAuthCacheForTesting resets the shared cache", async () => {
+      mockFetchResponse({ drafts: [], approved: [], published: [], rejected: [] });
+      mockFetchResponse({ drafts: [], approved: [], published: [], rejected: [] });
+
+      const { result } = renderHook(() => useGrowthApi());
+      await result.current.fetchDrafts();
+      expect(mockSignMessageAsync).toHaveBeenCalledTimes(1);
+
+      clearAuthCacheForTesting();
+
+      // Cache was cleared — next call must sign again even within TTL
       await result.current.fetchDrafts();
       expect(mockSignMessageAsync).toHaveBeenCalledTimes(2);
     });

--- a/website/test/useMultiChainNFTs.test.ts
+++ b/website/test/useMultiChainNFTs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { waitFor, cleanup } from "@testing-library/react";
+import { renderHookWithQuery } from "./testUtils";
 
 /**
  * Tests for useMultiChainNFTs hooks.
@@ -62,7 +63,7 @@ describe("useMultiChainUserNFTs", () => {
       isConnected: false,
     });
 
-    const { result } = renderHook(() => useMultiChainUserNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainUserNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -86,7 +87,7 @@ describe("useMultiChainUserNFTs", () => {
       return 0n;
     });
 
-    const { result } = renderHook(() => useMultiChainUserNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainUserNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -110,7 +111,7 @@ describe("useMultiChainUserNFTs", () => {
       return 0n;
     });
 
-    const { result } = renderHook(() => useMultiChainUserNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainUserNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -124,7 +125,7 @@ describe("useMultiChainUserNFTs", () => {
   it("should handle contract errors gracefully", async () => {
     mockReadContract.mockRejectedValue(new Error("Contract call failed"));
 
-    const { result } = renderHook(() => useMultiChainUserNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainUserNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -151,7 +152,7 @@ describe("useMultiChainUserNFTs", () => {
       return 0n;
     });
 
-    const { result } = renderHook(() => useMultiChainUserNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainUserNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -181,7 +182,7 @@ describe("useMultiChainPublicNFTs", () => {
       return [];
     });
 
-    const { result } = renderHook(() => useMultiChainPublicNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainPublicNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -196,7 +197,7 @@ describe("useMultiChainPublicNFTs", () => {
   it("should handle empty public NFT lists", async () => {
     mockReadContract.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useMultiChainPublicNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainPublicNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -208,7 +209,7 @@ describe("useMultiChainPublicNFTs", () => {
   it("should handle contract errors gracefully", async () => {
     mockReadContract.mockRejectedValue(new Error("Contract call failed"));
 
-    const { result } = renderHook(() => useMultiChainPublicNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainPublicNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -226,7 +227,7 @@ describe("useMultiChainPublicNFTs", () => {
       return [];
     });
 
-    const { result } = renderHook(() => useMultiChainPublicNFTs());
+    const { result } = renderHookWithQuery(() => useMultiChainPublicNFTs());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);

--- a/website/test/useNFTListedStatus.test.ts
+++ b/website/test/useNFTListedStatus.test.ts
@@ -5,8 +5,9 @@
  * Tests verify the contract call logic and state management.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { waitFor, act } from "@testing-library/react";
 import { useNFTListedStatus } from "../hooks/useNFTListedStatus";
+import { renderHookWithQuery } from "./testUtils";
 
 // Mock the readContract function from wagmi/actions
 const mockReadContract = vi.fn();
@@ -44,7 +45,7 @@ describe("useNFTListedStatus", () => {
     it("should call isListed contract function when enabled", async () => {
       mockReadContract.mockResolvedValue(true);
 
-      renderHook(() =>
+      renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -66,7 +67,7 @@ describe("useNFTListedStatus", () => {
     });
 
     it("should NOT call isListed when enabled=false", async () => {
-      renderHook(() =>
+      renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -86,7 +87,7 @@ describe("useNFTListedStatus", () => {
       mockReadContract.mockResolvedValue(false);
 
       // Test Optimism
-      const { unmount: unmount1 } = renderHook(() =>
+      const { unmount: unmount1 } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(1),
           network: "eip155:10",
@@ -107,7 +108,7 @@ describe("useNFTListedStatus", () => {
       vi.clearAllMocks();
 
       // Test Sepolia
-      renderHook(() =>
+      renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(1),
           network: "eip155:11155420",
@@ -130,7 +131,7 @@ describe("useNFTListedStatus", () => {
     it("should return isListed=true when contract returns true", async () => {
       mockReadContract.mockResolvedValue(true);
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -151,7 +152,7 @@ describe("useNFTListedStatus", () => {
     it("should return isListed=false when contract returns false", async () => {
       mockReadContract.mockResolvedValue(false);
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -167,7 +168,7 @@ describe("useNFTListedStatus", () => {
     it("should return error when contract call fails", async () => {
       mockReadContract.mockRejectedValue(new Error("Contract call failed"));
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -190,7 +191,7 @@ describe("useNFTListedStatus", () => {
       // Spy on console.error to verify it's NOT called for reverts
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(2), // Legacy token ID
           network: "eip155:10",
@@ -201,10 +202,10 @@ describe("useNFTListedStatus", () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      // Should set specific error message for legacy tokens
-      expect(result.current.error).toBe("isListed not available for this token");
-      // isListed should remain undefined (not an error state, just not supported)
-      expect(result.current.isListed).toBeUndefined();
+      // Legacy tokens return null gracefully — no error state
+      expect(result.current.error).toBeUndefined();
+      // isListed is null for legacy tokens (no listing support, not an error)
+      expect(result.current.isListed).toBeNull();
       // Should NOT log to console.error for expected contract reverts
       expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -212,7 +213,7 @@ describe("useNFTListedStatus", () => {
     });
 
     it("should return undefined isListed when disabled", async () => {
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -230,7 +231,7 @@ describe("useNFTListedStatus", () => {
     it("should allow optimistic update via setOptimisticListed", async () => {
       mockReadContract.mockResolvedValue(false);
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -242,11 +243,13 @@ describe("useNFTListedStatus", () => {
       });
 
       // Optimistically set to true (simulating user toggle)
-      act(() => {
+      await act(async () => {
         result.current.setOptimisticListed(true);
       });
 
-      expect(result.current.isListed).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isListed).toBe(true);
+      });
     });
   });
 
@@ -254,7 +257,7 @@ describe("useNFTListedStatus", () => {
     it("should refetch when refetch() is called", async () => {
       mockReadContract.mockResolvedValue(false);
 
-      const { result } = renderHook(() =>
+      const { result } = renderHookWithQuery(() =>
         useNFTListedStatus({
           tokenId: BigInt(42),
           network: "eip155:10",
@@ -276,7 +279,9 @@ describe("useNFTListedStatus", () => {
       });
 
       expect(mockReadContract).toHaveBeenCalledTimes(2);
-      expect(result.current.isListed).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isListed).toBe(true);
+      });
     });
   });
 
@@ -284,7 +289,7 @@ describe("useNFTListedStatus", () => {
     it("should refetch when tokenId changes", async () => {
       mockReadContract.mockResolvedValue(true);
 
-      const { result, rerender } = renderHook(
+      const { result, rerender } = renderHookWithQuery(
         ({ tokenId }) =>
           useNFTListedStatus({
             tokenId,
@@ -314,7 +319,7 @@ describe("useNFTListedStatus", () => {
       mockReadContract.mockResolvedValue(true);
 
       // Start with enabled=false (simulating isLoading state)
-      const { result, rerender } = renderHook(
+      const { result, rerender } = renderHookWithQuery(
         ({ enabled }) =>
           useNFTListedStatus({
             tokenId: BigInt(42),

--- a/website/utils/webmentionUtils.ts
+++ b/website/utils/webmentionUtils.ts
@@ -2,10 +2,13 @@
  * Utility functions for handling webmentions
  */
 
-interface Webmention {
+export interface Webmention {
   "wm-id": number;
   "wm-property": string;
-  [key: string]: unknown;
+  author: { name: string; photo?: string; url?: string };
+  content?: { text?: string; html?: string };
+  published?: string;
+  url: string;
 }
 
 interface WebmentionApiResponse {


### PR DESCRIPTION
# Migrate all manual fetch patterns to TanStack Query

## Summary

The website had `@tanstack/react-query` v5 installed (via `vike-react-query`) but made zero direct `useQuery` calls. Six components and four hooks managed async data with manual `fetch + useState + useEffect` patterns — no caching, no deduplication, no background refresh, per-component loading/error state reinvented every time.

This PR converts all of them to `useQuery` / `useMutation`.

## What changed

### Global config
- **`pages/+config.ts`** — added `queryClientConfig` with `staleTime: 60s`, `retry: 1`, `refetchOnWindowFocus: false` as site-wide defaults. These feed directly into `vike-react-query`'s auto-provisioned `QueryClient` — no manual `QueryClientProvider` needed.

### Components (removed `useState` + `useEffect` + manual fetch)
- **`CommentsSection.tsx`** — `useQuery` for fetching comments, `useMutation` for POST; on success the mutation appends the new comment directly into the cache via `setQueryData` without a round-trip refetch.
- **`Webmentions.tsx`** — `useQuery` wrapping the existing `fetchWebmentions` utility.
- **`LeafHistorySidebar.tsx`** — `useQuery` with `enabled: isOpen && !!address`; the sidebar only fetches when it's actually opened.
- **`NFTCard.tsx`** — `useQuery` combining the `tokenURI` contract read and metadata fetch into one cached entry keyed by `[tokenId, network]`. Two cards sharing the same `tokenURI` now share one fetch.
- **`NFTFloatImage.tsx`** — same pattern as NFTCard, simplified.

### Hooks
- **`useNFTListedStatus.ts`** — `useQuery` with `enabled` prop wired directly. Legacy tokens (contract reverts before `isListed` was added) return `null` from `queryFn` rather than throwing — no error state for an expected limitation. Optimistic updates via `queryClient.setQueryData`.
- **`useAgentInfo.ts`** — `useQuery` with `staleTime: Infinity` since the agent registration JSON rarely changes.
- **`useMultiChainNFTs.ts`** — both `useMultiChainUserNFTs` and `useMultiChainPublicNFTs` converted to `useQuery`; the per-network fetches extracted into plain async functions.
- **`useGrowthApi.ts`** — added `useGrowthDrafts`, `useGrowthInsights`, `useApproveDraft`, `useRejectDraft`, `useUpdateDraft` as proper TQ hooks. Mutations update the drafts cache via `setQueryData` on success (optimistic-style, no extra refetch). The existing `useGrowthApi` imperative interface is kept for backward compatibility.

### Growth page
- **`pages/growth/+Page.tsx`** — replaced manual `useState<ContentQueue>` + `loadData` callback + `useEffect` with the new hooks. `busy` state derived from `isPending` across the three mutation hooks; errors surfaced from TQ error state.

### Tests
- New **`test/testUtils.tsx`** — shared `renderWithQuery` and `renderHookWithQuery` helpers that wrap renders with a fresh `QueryClient` (`retry: false`, `staleTime: Infinity`, `gcTime: 0`).
- All 8 affected test files updated to use the wrappers; `GrowthPage.test.tsx` mock updated from the old imperative `useGrowthApi` interface to the new TQ hook shapes.

## Net result
- **20 files changed, 210 net lines deleted** (922 removed, 712 added — the additions are mostly the new hook wrappers and test utilities).
- 466/467 tests passing (1 pre-existing skip). Lint clean.
