### PR TITLE
Growth Agent: Engagement Metrics + UI Overhaul

### DIFF
--- a/growth-agent/agent/models.py
+++ b/growth-agent/agent/models.py
@@ -199,8 +199,8 @@ class PostMetrics(BaseModel):
     reblogs: int = 0
     favourites: int = 0
     replies: int = 0
-    link_clicks: int | None = None          # future: Umami UTM correlation
-    website_referral_sessions: int = 0      # future: Umami UTM correlation
+    link_clicks: int | None = None  # future: Umami UTM correlation
+    website_referral_sessions: int = 0  # future: Umami UTM correlation
 
 
 class Performance(BaseModel):

--- a/growth-agent/agent/models.py
+++ b/growth-agent/agent/models.py
@@ -189,6 +189,26 @@ class PlanningMemory(BaseModel):
     entries: list[PlanningMemoryEntry] = Field(default_factory=list)
 
 
+class PostMetrics(BaseModel):
+    """Engagement metrics for a single published post."""
+
+    id: str
+    channel: str
+    published_at: str
+    platform_id: str | None = None
+    reblogs: int = 0
+    favourites: int = 0
+    replies: int = 0
+    link_clicks: int | None = None          # future: Umami UTM correlation
+    website_referral_sessions: int = 0      # future: Umami UTM correlation
+
+
+class Performance(BaseModel):
+    """Aggregated engagement metrics for all published posts."""
+
+    posts: list[PostMetrics] = Field(default_factory=list)
+
+
 class DraftCritique(BaseModel):
     """Structured critique output for self-refine pattern."""
 

--- a/growth-agent/agent/nodes/ingest.py
+++ b/growth-agent/agent/nodes/ingest.py
@@ -124,17 +124,19 @@ def _collect_post_metrics(storage) -> None:
                     for draft in mastodon_published:
                         try:
                             status = masto.get_status(draft.platform_id)  # type: ignore[arg-type]
-                            performance_posts.append(PostMetrics(
-                                id=draft.id,
-                                channel="mastodon",
-                                published_at=(
-                                    draft.published_at.isoformat() if draft.published_at else ""
-                                ),
-                                platform_id=draft.platform_id,
-                                reblogs=status.get("reblogs_count", 0),
-                                favourites=status.get("favourites_count", 0),
-                                replies=status.get("replies_count", 0),
-                            ))
+                            performance_posts.append(
+                                PostMetrics(
+                                    id=draft.id,
+                                    channel="mastodon",
+                                    published_at=(
+                                        draft.published_at.isoformat() if draft.published_at else ""
+                                    ),
+                                    platform_id=draft.platform_id,
+                                    reblogs=status.get("reblogs_count", 0),
+                                    favourites=status.get("favourites_count", 0),
+                                    replies=status.get("replies_count", 0),
+                                )
+                            )
                         except Exception:
                             logger.warning("Failed to fetch Mastodon status %s", draft.platform_id)
             except Exception:
@@ -153,17 +155,19 @@ def _collect_post_metrics(storage) -> None:
                     for draft in bluesky_published:
                         post = posts_by_uri.get(draft.platform_id or "")
                         if post:
-                            performance_posts.append(PostMetrics(
-                                id=draft.id,
-                                channel="bluesky",
-                                published_at=(
-                                    draft.published_at.isoformat() if draft.published_at else ""
-                                ),
-                                platform_id=draft.platform_id,
-                                reblogs=post.get("repostCount", 0),
-                                favourites=post.get("likeCount", 0),
-                                replies=post.get("replyCount", 0),
-                            ))
+                            performance_posts.append(
+                                PostMetrics(
+                                    id=draft.id,
+                                    channel="bluesky",
+                                    published_at=(
+                                        draft.published_at.isoformat() if draft.published_at else ""
+                                    ),
+                                    platform_id=draft.platform_id,
+                                    reblogs=post.get("repostCount", 0),
+                                    favourites=post.get("likeCount", 0),
+                                    replies=post.get("replyCount", 0),
+                                )
+                            )
             except Exception:
                 logger.exception("Bluesky per-post metrics failed")
 

--- a/growth-agent/agent/nodes/ingest.py
+++ b/growth-agent/agent/nodes/ingest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 
-from agent.models import Insights, SocialMetrics, WebsiteAnalytics
+from agent.models import ContentQueue, Insights, Performance, PostMetrics, SocialMetrics, WebsiteAnalytics
 from agent.platforms.bluesky import BlueskyClient
 from agent.platforms.mastodon import MastodonClient
 from agent.state import AgentState
@@ -92,4 +92,71 @@ def ingest_analytics(storage) -> Insights:
 
     storage.write("insights.json", insights)
     logger.info("Analytics ingested")
+
+    # Per-post engagement metrics
+    _collect_post_metrics(storage)
+
     return insights
+
+
+def _collect_post_metrics(storage) -> None:
+    """Fetch per-post engagement counts from Mastodon and Bluesky, write performance.json."""
+    try:
+        queue = load_model(storage, "content_queue.json", ContentQueue)
+        published = queue.published
+        performance_posts: list[PostMetrics] = []
+
+        # Mastodon: one API call per published post
+        mastodon_published = [d for d in published if d.channel == "mastodon" and d.platform_id]
+        if mastodon_published:
+            try:
+                with MastodonClient(
+                    instance=os.environ.get("MASTODON_INSTANCE", "https://mastodon.social"),
+                    access_token=os.environ["MASTODON_ACCESS_TOKEN"],
+                ) as masto:
+                    for draft in mastodon_published:
+                        try:
+                            status = masto.get_status(draft.platform_id)  # type: ignore[arg-type]
+                            performance_posts.append(PostMetrics(
+                                id=draft.id,
+                                channel="mastodon",
+                                published_at=draft.published_at.isoformat() if draft.published_at else "",
+                                platform_id=draft.platform_id,
+                                reblogs=status.get("reblogs_count", 0),
+                                favourites=status.get("favourites_count", 0),
+                                replies=status.get("replies_count", 0),
+                            ))
+                        except Exception:
+                            logger.warning("Failed to fetch Mastodon status %s", draft.platform_id)
+            except Exception:
+                logger.exception("Mastodon per-post metrics failed")
+
+        # Bluesky: one feed fetch, then match by URI
+        bluesky_published = [d for d in published if d.channel == "bluesky" and d.platform_id]
+        if bluesky_published:
+            try:
+                with BlueskyClient(
+                    handle=os.environ.get("BLUESKY_HANDLE", "fretchen.eu"),
+                    app_password=os.environ["BLUESKY_APP_PASSWORD"],
+                ) as bsky:
+                    feed = bsky.get_author_feed(limit=100)
+                    feed_by_uri = {item["post"]["uri"]: item["post"] for item in feed}
+                    for draft in bluesky_published:
+                        post = feed_by_uri.get(draft.platform_id or "")
+                        if post:
+                            performance_posts.append(PostMetrics(
+                                id=draft.id,
+                                channel="bluesky",
+                                published_at=draft.published_at.isoformat() if draft.published_at else "",
+                                platform_id=draft.platform_id,
+                                reblogs=post.get("repostCount", 0),
+                                favourites=post.get("likeCount", 0),
+                                replies=post.get("replyCount", 0),
+                            ))
+            except Exception:
+                logger.exception("Bluesky per-post metrics failed")
+
+        storage.write("performance.json", Performance(posts=performance_posts))
+        logger.info("Per-post metrics collected: %d posts", len(performance_posts))
+    except Exception:
+        logger.exception("Per-post metrics collection failed")

--- a/growth-agent/agent/nodes/ingest.py
+++ b/growth-agent/agent/nodes/ingest.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import logging
 import os
 
-from agent.models import ContentQueue, Insights, Performance, PostMetrics, SocialMetrics, WebsiteAnalytics
+from agent.models import (
+    ContentQueue,
+    Insights,
+    Performance,
+    PostMetrics,
+    SocialMetrics,
+    WebsiteAnalytics,
+)
 from agent.platforms.bluesky import BlueskyClient
 from agent.platforms.mastodon import MastodonClient
 from agent.state import AgentState
@@ -120,7 +127,9 @@ def _collect_post_metrics(storage) -> None:
                             performance_posts.append(PostMetrics(
                                 id=draft.id,
                                 channel="mastodon",
-                                published_at=draft.published_at.isoformat() if draft.published_at else "",
+                                published_at=(
+                                    draft.published_at.isoformat() if draft.published_at else ""
+                                ),
                                 platform_id=draft.platform_id,
                                 reblogs=status.get("reblogs_count", 0),
                                 favourites=status.get("favourites_count", 0),
@@ -147,7 +156,9 @@ def _collect_post_metrics(storage) -> None:
                             performance_posts.append(PostMetrics(
                                 id=draft.id,
                                 channel="bluesky",
-                                published_at=draft.published_at.isoformat() if draft.published_at else "",
+                                published_at=(
+                                    draft.published_at.isoformat() if draft.published_at else ""
+                                ),
                                 platform_id=draft.platform_id,
                                 reblogs=post.get("repostCount", 0),
                                 favourites=post.get("likeCount", 0),

--- a/growth-agent/agent/nodes/ingest.py
+++ b/growth-agent/agent/nodes/ingest.py
@@ -37,7 +37,7 @@ def ingest_analytics(storage) -> Insights:
         website_id=os.environ.get("UMAMI_WEBSITE_ID", "e41ae7d9-a536-426d-b40e-f2488b11bf95"),
     )
     try:
-        start_at = ms_timestamp(days_ago=7)
+        start_at = ms_timestamp(days_ago=28)
         end_at = ms_timestamp(days_ago=0)
 
         stats = umami.get_stats(start_at, end_at)

--- a/growth-agent/agent/nodes/ingest.py
+++ b/growth-agent/agent/nodes/ingest.py
@@ -131,7 +131,7 @@ def _collect_post_metrics(storage) -> None:
             except Exception:
                 logger.exception("Mastodon per-post metrics failed")
 
-        # Bluesky: one feed fetch, then match by URI
+        # Bluesky: direct URI lookup via getPosts (no feed pollution, no 100-item cap)
         bluesky_published = [d for d in published if d.channel == "bluesky" and d.platform_id]
         if bluesky_published:
             try:
@@ -139,10 +139,10 @@ def _collect_post_metrics(storage) -> None:
                     handle=os.environ.get("BLUESKY_HANDLE", "fretchen.eu"),
                     app_password=os.environ["BLUESKY_APP_PASSWORD"],
                 ) as bsky:
-                    feed = bsky.get_author_feed(limit=100)
-                    feed_by_uri = {item["post"]["uri"]: item["post"] for item in feed}
+                    uris = [d.platform_id for d in bluesky_published]
+                    posts_by_uri = {p["uri"]: p for p in bsky.get_posts(uris)}  # type: ignore[arg-type]
                     for draft in bluesky_published:
-                        post = feed_by_uri.get(draft.platform_id or "")
+                        post = posts_by_uri.get(draft.platform_id or "")
                         if post:
                             performance_posts.append(PostMetrics(
                                 id=draft.id,

--- a/growth-agent/agent/platforms/bluesky.py
+++ b/growth-agent/agent/platforms/bluesky.py
@@ -84,6 +84,19 @@ class BlueskyClient:
         resp.raise_for_status()
         return resp.json().get("feed", [])
 
+    def get_posts(self, uris: list[str]) -> list[dict]:
+        """Fetch posts by AT URI in batches of 25, returning post objects with engagement counts."""
+        posts = []
+        for i in range(0, len(uris), 25):
+            batch = uris[i : i + 25]
+            resp = self.client.get(
+                f"{self.BASE_URL}/app.bsky.feed.getPosts",
+                params=[("uris", u) for u in batch],
+            )
+            resp.raise_for_status()
+            posts.extend(resp.json().get("posts", []))
+        return posts
+
     @staticmethod
     def _detect_link_facet(text: str, link: str) -> list[dict]:
         """Create a link facet if the link appears in the text."""

--- a/growth-agent/agent/platforms/mastodon.py
+++ b/growth-agent/agent/platforms/mastodon.py
@@ -39,6 +39,11 @@ class MastodonClient:
         resp = self.client.delete(f"/api/v1/statuses/{status_id}")
         resp.raise_for_status()
 
+    def get_status(self, status_id: str) -> dict:
+        resp = self.client.get(f"/api/v1/statuses/{status_id}")
+        resp.raise_for_status()
+        return resp.json()
+
     def get_account_statuses(self, account_id: str, limit: int = 20) -> list[dict]:
         resp = self.client.get(f"/api/v1/accounts/{account_id}/statuses", params={"limit": limit})
         resp.raise_for_status()

--- a/growth-agent/notebooks/01_umami_ingest.ipynb
+++ b/growth-agent/notebooks/01_umami_ingest.ipynb
@@ -16,17 +16,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "f211f66d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using S3 prefix: growth-agent-dev/  ✓\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "sys.path.insert(0, '..')\n",
@@ -45,19 +38,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7195f5ab",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "API Key loaded: yes\n",
-      "Website ID: e41ae7d9-a536-426d-b40e-f2488b11bf95\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "sys.path.insert(0, '..')\n",
@@ -88,18 +72,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c84ac315",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Active users right now: {'visitors': 0}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from agent.umami_client import UmamiClient, ms_timestamp\n",
     "\n",
@@ -120,23 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "a9bdf799",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Website stats (7 days):\n",
-      "  pageviews: 74\n",
-      "  visitors: 54\n",
-      "  visits: 55\n",
-      "  bounces: 51\n",
-      "  totaltime: 122\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "start = ms_timestamp(days_ago=7)\n",
     "end = ms_timestamp(days_ago=0)\n",
@@ -158,33 +121,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "faffe5d7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Top pages:\n",
-      "     21 visitors — /\n",
-      "      6 visitors — /amo/13/\n",
-      "      5 visitors — /blog/\n",
-      "      5 visitors — /amo/10\n",
-      "      3 visitors — /amo/11\n",
-      "      3 visitors — /de/blog/\n",
-      "      3 visitors — /blog/29/\n",
-      "      2 visitors — /blog/27/\n",
-      "      2 visitors — /de/blog/27/\n",
-      "      1 visitors — /quantum/qml/\n",
-      "      1 visitors — /quantum/amo/18/\n",
-      "      1 visitors — /de/quantum/amo/5/\n",
-      "      1 visitors — /blog/12/\n",
-      "      1 visitors — /de/quantum/amo/6/\n",
-      "      1 visitors — /quantum/hardware/4/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "top_pages = umami.get_metrics(start_at=start, end_at=end, metric_type='path', limit=15)\n",
     "print('Top pages:')\n",
@@ -202,20 +142,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "751f1beb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Top referrers:\n",
-      "      2 visitors — fretchen.eu\n",
-      "      1 visitors — go.bsky.app\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "referrers = umami.get_metrics(start_at=start, end_at=end, metric_type='referrer', limit=15)\n",
     "print('Top referrers:')\n",
@@ -233,22 +163,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5fd14e63",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tracked events:\n",
-      "      1x — imagegen-connect-hover\n",
-      "      1x — wallet-dropdown-close\n",
-      "      1x — wallet-dropdown-open\n",
-      "      1x — blog-support-button-hover\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "events = umami.get_metrics(start_at=start, end_at=end, metric_type='event', limit=30)\n",
     "print('Tracked events:')\n",
@@ -266,34 +184,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "f7f6f373",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Daily pageviews:\n",
-      "  2026-05-30 — 10 views\n",
-      "  2026-05-31 — 1 views\n",
-      "  2026-06-01 — 6 views\n",
-      "  2026-06-02 — 21 views\n",
-      "  2026-06-03 — 7 views\n",
-      "  2026-06-04 — 7 views\n",
-      "  2026-06-05 — 22 views\n",
-      "\n",
-      "Daily sessions:\n",
-      "  2026-05-30 — 10 sessions\n",
-      "  2026-05-31 — 1 sessions\n",
-      "  2026-06-01 — 6 sessions\n",
-      "  2026-06-02 — 8 sessions\n",
-      "  2026-06-03 — 7 sessions\n",
-      "  2026-06-04 — 5 sessions\n",
-      "  2026-06-05 — 17 sessions\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pageviews = umami.get_pageviews(start_at=start, end_at=end, unit='day')\n",
     "print('Daily pageviews:')\n",
@@ -307,18 +201,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "128094e3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Insights parsed: 54 visitors, 10 top pages\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from datetime import datetime\n",
     "from agent.models import Insights, WebsiteAnalytics\n",
@@ -351,19 +237,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "8fce0a0e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved and loaded insights.json (746 chars)\n",
-      "Top page: {'x': '/', 'y': 21}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from agent.storage import S3Storage\n",
     "\n",
@@ -383,18 +260,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "31325795",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done — Umami ingestion validated.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "umami.close()\n",
     "print('Done — Umami ingestion validated.')"
@@ -402,6 +271,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fa825976",
    "metadata": {},
    "source": [
     "## 8. Per-post Engagement Metrics\n",
@@ -413,17 +283,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "367795f5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Copied growth-agent/content_queue.json → growth-agent-dev/content_queue.json\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Copy prod content_queue.json → dev prefix (prod is read-only here)\n",
     "import boto3\n",
@@ -449,17 +312,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "id": "58464d3b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Done — performance.json written to dev prefix\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Run metrics collection against the copied queue\n",
     "from agent.nodes.ingest import _collect_post_metrics\n",
@@ -470,81 +326,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
+   "id": "7888d526",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Posts with metrics: 64\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  1  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  1  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  1  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202501…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  2  🔁  0  💬  1  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  2  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  1  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n",
-      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Display results\n",
     "from agent.storage import load_model\n",

--- a/growth-agent/notebooks/01_umami_ingest.ipynb
+++ b/growth-agent/notebooks/01_umami_ingest.ipynb
@@ -5,7 +5,7 @@
    "id": "cb37534f",
    "metadata": {},
    "source": [
-    "# 01 \u2014 Umami Analytics Ingestion\n",
+    "# 01 — Umami Analytics Ingestion\n",
     "\n",
     "Validate the Umami Cloud REST API integration:\n",
     "- Connect with API key\n",
@@ -16,9 +16,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using S3 prefix: growth-agent-dev/  ✓\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "sys.path.insert(0, '..')\n",
@@ -29,18 +37,27 @@
     "prefix = os.getenv(\"S3_STATE_PREFIX\", \"growth-agent/\")\n",
     "if prefix == \"growth-agent/\":\n",
     "    raise RuntimeError(\n",
-    "        f\"S3_STATE_PREFIX is {prefix!r} \u2014 this is the PRODUCTION prefix. \"\n",
+    "        f\"S3_STATE_PREFIX is {prefix!r} — this is the PRODUCTION prefix. \"\n",
     "        \"Set S3_STATE_PREFIX=growth-agent-dev/ in .env before running notebooks.\"\n",
     "    )\n",
-    "print(f\"Using S3 prefix: {prefix}  \u2713\")\n"
+    "print(f\"Using S3 prefix: {prefix}  ✓\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7195f5ab",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API Key loaded: yes\n",
+      "Website ID: e41ae7d9-a536-426d-b40e-f2488b11bf95\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "sys.path.insert(0, '..')\n",
@@ -53,7 +70,7 @@
     "UMAMI_API_KEY = os.getenv('UMAMI_API_KEY')\n",
     "UMAMI_WEBSITE_ID = os.getenv('UMAMI_WEBSITE_ID', 'e41ae7d9-a536-426d-b40e-f2488b11bf95')\n",
     "\n",
-    "print(f'API Key loaded: {\"yes\" if UMAMI_API_KEY else \"NO \u2014 create .env from .env.example\"}')\n",
+    "print(f'API Key loaded: {\"yes\" if UMAMI_API_KEY else \"NO — create .env from .env.example\"}')\n",
     "print(f'Website ID: {UMAMI_WEBSITE_ID}')"
    ]
   },
@@ -71,10 +88,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "c84ac315",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Active users right now: {'visitors': 0}\n"
+     ]
+    }
+   ],
    "source": [
     "from agent.umami_client import UmamiClient, ms_timestamp\n",
     "\n",
@@ -95,10 +120,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "a9bdf799",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Website stats (7 days):\n",
+      "  pageviews: 74\n",
+      "  visitors: 54\n",
+      "  visits: 55\n",
+      "  bounces: 51\n",
+      "  totaltime: 122\n"
+     ]
+    }
+   ],
    "source": [
     "start = ms_timestamp(days_ago=7)\n",
     "end = ms_timestamp(days_ago=0)\n",
@@ -120,15 +158,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "faffe5d7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top pages:\n",
+      "     21 visitors — /\n",
+      "      6 visitors — /amo/13/\n",
+      "      5 visitors — /blog/\n",
+      "      5 visitors — /amo/10\n",
+      "      3 visitors — /amo/11\n",
+      "      3 visitors — /de/blog/\n",
+      "      3 visitors — /blog/29/\n",
+      "      2 visitors — /blog/27/\n",
+      "      2 visitors — /de/blog/27/\n",
+      "      1 visitors — /quantum/qml/\n",
+      "      1 visitors — /quantum/amo/18/\n",
+      "      1 visitors — /de/quantum/amo/5/\n",
+      "      1 visitors — /blog/12/\n",
+      "      1 visitors — /de/quantum/amo/6/\n",
+      "      1 visitors — /quantum/hardware/4/\n"
+     ]
+    }
+   ],
    "source": [
     "top_pages = umami.get_metrics(start_at=start, end_at=end, metric_type='path', limit=15)\n",
     "print('Top pages:')\n",
     "for page in top_pages:\n",
-    "    print(f'  {page[\"y\"]:>5} visitors \u2014 {page[\"x\"]}')"
+    "    print(f'  {page[\"y\"]:>5} visitors — {page[\"x\"]}')"
    ]
   },
   {
@@ -141,15 +202,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "751f1beb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top referrers:\n",
+      "      2 visitors — fretchen.eu\n",
+      "      1 visitors — go.bsky.app\n"
+     ]
+    }
+   ],
    "source": [
     "referrers = umami.get_metrics(start_at=start, end_at=end, metric_type='referrer', limit=15)\n",
     "print('Top referrers:')\n",
     "for ref in referrers:\n",
-    "    print(f'  {ref[\"y\"]:>5} visitors \u2014 {ref[\"x\"]}')"
+    "    print(f'  {ref[\"y\"]:>5} visitors — {ref[\"x\"]}')"
    ]
   },
   {
@@ -162,15 +233,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "5fd14e63",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tracked events:\n",
+      "      1x — imagegen-connect-hover\n",
+      "      1x — wallet-dropdown-close\n",
+      "      1x — wallet-dropdown-open\n",
+      "      1x — blog-support-button-hover\n"
+     ]
+    }
+   ],
    "source": [
     "events = umami.get_metrics(start_at=start, end_at=end, metric_type='event', limit=30)\n",
     "print('Tracked events:')\n",
     "for event in events:\n",
-    "    print(f'  {event[\"y\"]:>5}x \u2014 {event[\"x\"]}')"
+    "    print(f'  {event[\"y\"]:>5}x — {event[\"x\"]}')"
    ]
   },
   {
@@ -183,27 +266,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "f7f6f373",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Daily pageviews:\n",
+      "  2026-05-30 — 10 views\n",
+      "  2026-05-31 — 1 views\n",
+      "  2026-06-01 — 6 views\n",
+      "  2026-06-02 — 21 views\n",
+      "  2026-06-03 — 7 views\n",
+      "  2026-06-04 — 7 views\n",
+      "  2026-06-05 — 22 views\n",
+      "\n",
+      "Daily sessions:\n",
+      "  2026-05-30 — 10 sessions\n",
+      "  2026-05-31 — 1 sessions\n",
+      "  2026-06-01 — 6 sessions\n",
+      "  2026-06-02 — 8 sessions\n",
+      "  2026-06-03 — 7 sessions\n",
+      "  2026-06-04 — 5 sessions\n",
+      "  2026-06-05 — 17 sessions\n"
+     ]
+    }
+   ],
    "source": [
     "pageviews = umami.get_pageviews(start_at=start, end_at=end, unit='day')\n",
     "print('Daily pageviews:')\n",
     "for pv in pageviews.get('pageviews', []):\n",
-    "    print(f'  {pv[\"x\"][:10]} \u2014 {pv[\"y\"]} views')\n",
+    "    print(f'  {pv[\"x\"][:10]} — {pv[\"y\"]} views')\n",
     "\n",
     "print('\\nDaily sessions:')\n",
     "for s in pageviews.get('sessions', []):\n",
-    "    print(f'  {s[\"x\"][:10]} \u2014 {s[\"y\"]} sessions')"
+    "    print(f'  {s[\"x\"][:10]} — {s[\"y\"]} sessions')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "128094e3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Insights parsed: 54 visitors, 10 top pages\n"
+     ]
+    }
+   ],
    "source": [
     "from datetime import datetime\n",
     "from agent.models import Insights, WebsiteAnalytics\n",
@@ -236,10 +351,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "8fce0a0e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved and loaded insights.json (746 chars)\n",
+      "Top page: {'x': '/', 'y': 21}\n"
+     ]
+    }
+   ],
    "source": [
     "from agent.storage import S3Storage\n",
     "\n",
@@ -259,13 +383,177 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "31325795",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done — Umami ingestion validated.\n"
+     ]
+    }
+   ],
    "source": [
     "umami.close()\n",
-    "print('Done \u2014 Umami ingestion validated.')"
+    "print('Done — Umami ingestion validated.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Per-post Engagement Metrics\n",
+    "\n",
+    "Copy the production `content_queue.json` into the dev prefix (read-only from prod), then run `_collect_post_metrics()` to validate the new metrics collection code.\n",
+    "\n",
+    "Requires `S3_STATE_PREFIX_PROD` env var set to the production prefix (e.g. `growth-agent/`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copied growth-agent/content_queue.json → growth-agent-dev/content_queue.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Copy prod content_queue.json → dev prefix (prod is read-only here)\n",
+    "import boto3\n",
+    "\n",
+    "prod_prefix = os.environ[\"S3_STATE_PREFIX_PROD\"]  # e.g. \"growth-agent/\"\n",
+    "dev_prefix = os.getenv(\"S3_STATE_PREFIX\", \"growth-agent-dev/\")\n",
+    "bucket = os.environ[\"S3_BUCKET\"]\n",
+    "\n",
+    "s3_raw = boto3.client(\n",
+    "    \"s3\",\n",
+    "    region_name=\"nl-ams\",\n",
+    "    endpoint_url=\"https://s3.nl-ams.scw.cloud\",\n",
+    "    aws_access_key_id=os.environ[\"SCW_ACCESS_KEY\"],\n",
+    "    aws_secret_access_key=os.environ[\"SCW_SECRET_KEY\"],\n",
+    ")\n",
+    "s3_raw.copy_object(\n",
+    "    Bucket=bucket,\n",
+    "    CopySource={\"Bucket\": bucket, \"Key\": prod_prefix + \"content_queue.json\"},\n",
+    "    Key=dev_prefix + \"content_queue.json\",\n",
+    ")\n",
+    "print(f\"Copied {prod_prefix}content_queue.json → {dev_prefix}content_queue.json\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done — performance.json written to dev prefix\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run metrics collection against the copied queue\n",
+    "from agent.nodes.ingest import _collect_post_metrics\n",
+    "\n",
+    "_collect_post_metrics(store)\n",
+    "print(\"Done — performance.json written to dev prefix\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Posts with metrics: 64\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20251…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  1  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  1  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  1  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  1  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [mastodon] ❤️  0  🔁  0  💬  0  — recovered_mastodon_20260…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202501…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  2  🔁  0  💬  1  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202604…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  2  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  1  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  1  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202605…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n",
+      "  [bluesky ] ❤️  0  🔁  0  💬  0  — recovered_bluesky_202606…\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Display results\n",
+    "from agent.storage import load_model\n",
+    "from agent.models import Performance\n",
+    "\n",
+    "perf = load_model(store, \"performance.json\", Performance)\n",
+    "print(f\"Posts with metrics: {len(perf.posts)}\")\n",
+    "for p in perf.posts:\n",
+    "    print(f\"  [{p.channel:8}] ❤️{p.favourites:3}  🔁{p.reblogs:3}  💬{p.replies:3}  — {p.id[:24]}…\")\n"
    ]
   }
  ],

--- a/growth-agent/test/test_handler.py
+++ b/growth-agent/test/test_handler.py
@@ -183,7 +183,9 @@ def test_collect_post_metrics_mastodon(MockMasto, mock_storage):
 
     masto_ctx = MagicMock()
     masto_ctx.get_status.return_value = {
-        "reblogs_count": 3, "favourites_count": 7, "replies_count": 1
+        "reblogs_count": 3,
+        "favourites_count": 7,
+        "replies_count": 1,
     }
     MockMasto.return_value.__enter__ = MagicMock(return_value=masto_ctx)
     MockMasto.return_value.__exit__ = MagicMock(return_value=False)

--- a/growth-agent/test/test_handler.py
+++ b/growth-agent/test/test_handler.py
@@ -15,6 +15,7 @@ from agent.models import (
     Insights,
     LLMAnalysis,
     PageForSocial,
+    Performance,
     WebsiteAnalytics,
 )
 from agent.nodes.drafts import (
@@ -23,7 +24,7 @@ from agent.nodes.drafts import (
     _normalize_url,
     create_drafts,
 )
-from agent.nodes.ingest import ingest_analytics
+from agent.nodes.ingest import _collect_post_metrics, ingest_analytics
 from agent.nodes.insights import generate_insights
 from agent.nodes.plan import (
     PIPELINE_TARGET,
@@ -156,6 +157,114 @@ def test_ingest_analytics_old_umami_format(MockUmami, MockMasto, MockBsky, mock_
     result = ingest_analytics(storage)
     assert result.website_analytics.pageviews == 500
     assert result.website_analytics.visitors == 120
+
+
+# ---------------------------------------------------------------------------
+# _collect_post_metrics
+# ---------------------------------------------------------------------------
+
+
+@patch("agent.nodes.ingest.MastodonClient")
+def test_collect_post_metrics_mastodon(MockMasto, mock_storage):
+    storage, store = mock_storage
+    queue = ContentQueue(
+        published=[
+            Draft(
+                id="d1",
+                channel="mastodon",
+                language="en",
+                content="x",
+                platform_id="111",
+                published_at=datetime.now(timezone.utc),
+            )
+        ]
+    )
+    storage.write("content_queue.json", queue)
+
+    masto_ctx = MagicMock()
+    masto_ctx.get_status.return_value = {"reblogs_count": 3, "favourites_count": 7, "replies_count": 1}
+    MockMasto.return_value.__enter__ = MagicMock(return_value=masto_ctx)
+    MockMasto.return_value.__exit__ = MagicMock(return_value=False)
+
+    _collect_post_metrics(storage)
+
+    perf = Performance.model_validate(store["performance.json"])
+    assert len(perf.posts) == 1
+    assert perf.posts[0].reblogs == 3
+    assert perf.posts[0].favourites == 7
+    assert perf.posts[0].replies == 1
+
+
+@patch("agent.nodes.ingest.BlueskyClient")
+def test_collect_post_metrics_bluesky(MockBsky, mock_storage):
+    storage, store = mock_storage
+    uri = "at://did:plc:abc/app.bsky.feed.post/123"
+    queue = ContentQueue(
+        published=[
+            Draft(
+                id="d2",
+                channel="bluesky",
+                language="en",
+                content="x",
+                platform_id=uri,
+                published_at=datetime.now(timezone.utc),
+            )
+        ]
+    )
+    storage.write("content_queue.json", queue)
+
+    bsky_ctx = MagicMock()
+    bsky_ctx.get_posts.return_value = [
+        {"uri": uri, "repostCount": 2, "likeCount": 5, "replyCount": 0},
+    ]
+    MockBsky.return_value.__enter__ = MagicMock(return_value=bsky_ctx)
+    MockBsky.return_value.__exit__ = MagicMock(return_value=False)
+
+    _collect_post_metrics(storage)
+
+    perf = Performance.model_validate(store["performance.json"])
+    assert len(perf.posts) == 1
+    assert perf.posts[0].favourites == 5
+    assert perf.posts[0].reblogs == 2
+    assert perf.posts[0].replies == 0
+
+
+def test_collect_post_metrics_no_published(mock_storage):
+    storage, store = mock_storage
+    storage.write("content_queue.json", ContentQueue())
+
+    _collect_post_metrics(storage)
+
+    perf = Performance.model_validate(store["performance.json"])
+    assert perf.posts == []
+
+
+@patch("agent.nodes.ingest.MastodonClient")
+def test_collect_post_metrics_mastodon_api_failure(MockMasto, mock_storage):
+    storage, store = mock_storage
+    queue = ContentQueue(
+        published=[
+            Draft(
+                id="d3",
+                channel="mastodon",
+                language="en",
+                content="x",
+                platform_id="999",
+                published_at=datetime.now(timezone.utc),
+            )
+        ]
+    )
+    storage.write("content_queue.json", queue)
+
+    masto_ctx = MagicMock()
+    masto_ctx.get_status.side_effect = Exception("API error")
+    MockMasto.return_value.__enter__ = MagicMock(return_value=masto_ctx)
+    MockMasto.return_value.__exit__ = MagicMock(return_value=False)
+
+    _collect_post_metrics(storage)  # must not raise
+
+    perf = Performance.model_validate(store["performance.json"])
+    assert perf.posts == []
 
 
 # ---------------------------------------------------------------------------

--- a/growth-agent/test/test_handler.py
+++ b/growth-agent/test/test_handler.py
@@ -182,7 +182,9 @@ def test_collect_post_metrics_mastodon(MockMasto, mock_storage):
     storage.write("content_queue.json", queue)
 
     masto_ctx = MagicMock()
-    masto_ctx.get_status.return_value = {"reblogs_count": 3, "favourites_count": 7, "replies_count": 1}
+    masto_ctx.get_status.return_value = {
+        "reblogs_count": 3, "favourites_count": 7, "replies_count": 1
+    }
     MockMasto.return_value.__enter__ = MagicMock(return_value=masto_ctx)
     MockMasto.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/growth-agent/test/test_handler.py
+++ b/growth-agent/test/test_handler.py
@@ -1251,3 +1251,25 @@ def test_old_queue_deserializes_without_published_at():
     }
     queue = ContentQueue.model_validate(raw)
     assert queue.published[0].published_at is None
+
+
+# ---------------------------------------------------------------------------
+# BlueskyClient.get_posts — batching behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_bluesky_get_posts_batches():
+    """URIs beyond 25 trigger a second HTTP request."""
+    from agent.platforms.bluesky import BlueskyClient
+
+    bsky = BlueskyClient.__new__(BlueskyClient)
+    mock_http = MagicMock()
+    bsky.client = mock_http
+    mock_http.get.return_value.raise_for_status = MagicMock()
+    mock_http.get.return_value.json.return_value = {"posts": [{"uri": "x"}]}
+
+    uris = [f"at://did/post/{i}" for i in range(26)]
+    result = bsky.get_posts(uris)
+
+    assert mock_http.get.call_count == 2  # batch of 25 + batch of 1
+    assert len(result) == 2  # one entry per batch response

--- a/website/hooks/useGrowthApi.ts
+++ b/website/hooks/useGrowthApi.ts
@@ -58,6 +58,20 @@ export function useGrowthInsights(enabled: boolean) {
   });
 }
 
+export function useGrowthPerformance(enabled: boolean) {
+  const { address } = useAccount();
+  const getAuth = useGrowthAuth();
+
+  return useQuery<Performance>({
+    queryKey: ["growthPerformance", address],
+    queryFn: async () => {
+      const auth = await getAuth();
+      return apiFetch<Performance>("performance", auth);
+    },
+    enabled: enabled && !!address,
+  });
+}
+
 export function useUpdateDraft() {
   const { address } = useAccount();
   const getAuth = useGrowthAuth();

--- a/website/layouts/LayoutDefault.tsx
+++ b/website/layouts/LayoutDefault.tsx
@@ -6,9 +6,11 @@ import WalletOptions from "../components/WalletOptions";
 import LanguageToggle from "../components/LanguageToggle";
 import Footer from "../components/Footer";
 
-import { WagmiProvider } from "wagmi";
+import { WagmiProvider, useAccount } from "wagmi";
 import { config } from "../wagmi.config";
 import { layout } from "./styles";
+import { useIsMounted } from "../hooks/useIsMounted";
+import { OWNER_ADDRESS } from "../utils/getChain";
 
 export default function LayoutDefault({ children }: { children: React.ReactNode }) {
   const navigationRef = useRef<HTMLDivElement>(null);
@@ -61,6 +63,7 @@ export default function LayoutDefault({ children }: { children: React.ReactNode 
               <div className={layout.navigationLink}>
                 <Link href="/lab">Lab</Link>
               </div>
+              <GrowthNavLink />
             </div>
             <div className={layout.scrollIndicator} ref={scrollIndicatorRef}></div>
             <div className={layout.headerControls}>
@@ -92,6 +95,18 @@ function Content({ children }: { children: React.ReactNode }) {
       <div id="page-content" className={layout.content}>
         {children}
       </div>
+    </div>
+  );
+}
+
+function GrowthNavLink() {
+  const hasMounted = useIsMounted();
+  const { address, status } = useAccount();
+  const isOwner = hasMounted && status === "connected" && address?.toLowerCase() === OWNER_ADDRESS.toLowerCase();
+  if (!isOwner) return null;
+  return (
+    <div className={layout.navigationLink}>
+      <Link href="/growth">Growth</Link>
     </div>
   );
 }

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -307,6 +307,15 @@ const reviewMeta = css({
   whiteSpace: "pre-wrap",
 });
 
+const pageGroupRow = css({
+  border: "1px solid",
+  borderColor: "gray.200",
+  borderRadius: "md",
+  mb: "sm",
+  backgroundColor: "white",
+  overflow: "hidden",
+});
+
 // ===== Sub-components =====
 
 function DraftCardView({
@@ -608,6 +617,54 @@ export default function Page() {
     return map;
   }, [performance?.posts]);
 
+  const pageGroups = useMemo(() => {
+    const trafficByPath = new Map<string, number>();
+    for (const p of insights?.website_analytics?.top_pages ?? []) {
+      trafficByPath.set(p.x as string, p.y as number);
+    }
+
+    const map = new Map<string, {
+      url: string;
+      drafts: Draft[];
+      totalEngagement: { favourites: number; reblogs: number; replies: number };
+      lastPublished: string | null;
+      channels: Set<string>;
+      pageviews: number | null;
+    }>();
+
+    for (const draft of queue?.published ?? []) {
+      const url = draft.link ?? draft.source_blog_post ?? "(no link)";
+      if (!map.has(url)) {
+        let path: string | null = null;
+        try { path = new URL(url).pathname; } catch { /* invalid url */ }
+        map.set(url, {
+          url,
+          drafts: [],
+          totalEngagement: { favourites: 0, reblogs: 0, replies: 0 },
+          lastPublished: null,
+          channels: new Set(),
+          pageviews: path !== null ? (trafficByPath.get(path) ?? null) : null,
+        });
+      }
+      const group = map.get(url)!;
+      group.drafts.push(draft);
+      group.channels.add(draft.channel);
+      const m = metricsByDraftId[draft.id];
+      if (m) {
+        group.totalEngagement.favourites += m.favourites;
+        group.totalEngagement.reblogs += m.reblogs;
+        group.totalEngagement.replies += m.replies;
+      }
+      if (draft.published_at && (!group.lastPublished || draft.published_at > group.lastPublished)) {
+        group.lastPublished = draft.published_at;
+      }
+    }
+
+    return [...map.values()].sort((a, b) =>
+      (b.lastPublished ?? "").localeCompare(a.lastPublished ?? "")
+    );
+  }, [queue?.published, insights?.website_analytics?.top_pages, metricsByDraftId]);
+
   const handleApprove = async (id: string, scheduledAt?: string, reviewComment?: string) => {
     await approveMutation.mutateAsync({ id, scheduledAt, reviewComment });
   };
@@ -700,7 +757,65 @@ export default function Page() {
             ))}
           </div>
 
-          {currentDrafts.length === 0 ? (
+          {tab === "published" ? (
+            pageGroups.length === 0 ? (
+              <p className={infoBox}>No published posts.</p>
+            ) : (
+              pageGroups.map((group) => {
+                const eng = group.totalEngagement;
+                const hasEngagement = eng.favourites + eng.reblogs + eng.replies > 0;
+                let displayUrl = group.url;
+                try { displayUrl = new URL(group.url).pathname; } catch { /* keep full url */ }
+                return (
+                  <details key={group.url} className={pageGroupRow}>
+                    <summary style={{ cursor: "pointer", padding: "10px 12px", display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                      <a
+                        href={group.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ color: "#2563eb", textDecoration: "underline", fontSize: "14px", fontWeight: 500, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {displayUrl}
+                      </a>
+                      <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>{group.drafts.length}×</span>
+                      {group.lastPublished && (
+                        <span style={{ fontSize: "12px", color: "#777", whiteSpace: "nowrap" }}>
+                          {new Date(group.lastPublished).toLocaleDateString()}
+                        </span>
+                      )}
+                      <span style={{ whiteSpace: "nowrap" }}>
+                        {[...group.channels].map((ch) => ch === "mastodon" ? "🐘" : "🦋").join(" ")}
+                      </span>
+                      {hasEngagement && (
+                        <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>
+                          ❤️ {eng.favourites} 🔁 {eng.reblogs} 💬 {eng.replies}
+                        </span>
+                      )}
+                      <span style={{ fontSize: "12px", color: group.pageviews !== null ? "#555" : "#aaa", whiteSpace: "nowrap" }}>
+                        {group.pageviews !== null ? `${group.pageviews} views (28d)` : "—"}
+                      </span>
+                    </summary>
+                    <div style={{ borderTop: "1px solid #e5e7eb", padding: "8px 12px" }}>
+                      {group.drafts.map((draft) => (
+                        <DraftCardView
+                          key={draft.id}
+                          draft={draft}
+                          showActions={false}
+                          history={[]}
+                          metrics={metricsByDraftId[draft.id]}
+                          onApprove={handleApprove}
+                          onReject={handleReject}
+                          onUpdate={handleUpdate}
+                          busy={busy}
+                        />
+                      ))}
+                    </div>
+                  </details>
+                );
+              })
+            )
+          ) : currentDrafts.length === 0 ? (
             <p className={infoBox}>No {tab} drafts.</p>
           ) : (
             currentDrafts.map((draft) => (

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -19,6 +19,8 @@ type Tab = "drafts" | "approved" | "published" | "rejected";
 
 // ===== Styles =====
 
+const growthContainer = css({ maxWidth: "900px", mx: "auto", px: "md", pt: "md" });
+
 const infoBox = css({
   padding: "lg",
   textAlign: "center",
@@ -269,6 +271,45 @@ const pageGroupRow = css({
   overflow: "hidden",
 });
 
+const pageGroupSummaryRow = css({
+  cursor: "pointer",
+  padding: "sm md",
+  display: "flex",
+  alignItems: "center",
+  gap: "xs",
+  flexWrap: "wrap",
+});
+
+const pageGroupLink = css({
+  color: "blue.600",
+  textDecoration: "underline",
+  fontSize: "sm",
+  fontWeight: "medium",
+  flex: 1,
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const pageGroupMeta = css({
+  fontSize: "xs",
+  color: "gray.600",
+  whiteSpace: "nowrap",
+});
+
+const pageGroupDim = css({
+  fontSize: "xs",
+  color: "gray.400",
+  whiteSpace: "nowrap",
+});
+
+const pageGroupBody = css({
+  borderTop: "1px solid",
+  borderColor: "gray.200",
+  padding: "sm md",
+});
+
 // ===== Sub-components =====
 
 function DraftCardView({
@@ -493,7 +534,9 @@ function InsightsSection({ insights }: { insights: Insights | null }) {
   return (
     <div className={insightsPanel}>
       <details>
-        <summary style={{ cursor: "pointer", fontWeight: "bold", marginBottom: "8px" }}>Insights & Analytics</summary>
+        <summary style={{ cursor: "pointer", fontWeight: "bold", marginBottom: "8px" }}>
+          Insights & Analytics (28 days)
+        </summary>
         {(insights.growth_opportunities ?? []).length > 0 && (
           <>
             <h4 style={{ fontWeight: 600, marginBottom: "4px" }}>Growth Opportunities</h4>
@@ -552,7 +595,7 @@ export default function Page() {
   const historyByPage = useMemo(() => {
     const map: Record<string, Draft[]> = {};
     for (const d of queue?.published ?? []) {
-      const key = d.source_blog_post ?? "";
+      const key = d.link ?? d.source_blog_post ?? "";
       if (!key) continue;
       (map[key] ??= []).push(d);
     }
@@ -580,6 +623,7 @@ export default function Page() {
       string,
       {
         url: string;
+        displayUrl: string;
         drafts: Draft[];
         totalEngagement: { favourites: number; reblogs: number; replies: number };
         lastPublished: string | null;
@@ -591,19 +635,20 @@ export default function Page() {
     for (const draft of queue?.published ?? []) {
       const url = draft.link ?? draft.source_blog_post ?? "(no link)";
       if (!map.has(url)) {
-        let path: string | null = null;
+        let path: string;
         try {
           path = new URL(url).pathname;
         } catch {
-          /* invalid url */
+          path = url;
         }
         map.set(url, {
           url,
+          displayUrl: path,
           drafts: [],
           totalEngagement: { favourites: 0, reblogs: 0, replies: 0 },
           lastPublished: null,
           channels: new Set(),
-          pageviews: path !== null ? (trafficByPath.get(path) ?? null) : null,
+          pageviews: trafficByPath.get(path) ?? null,
         });
       }
       const group = map.get(url)!;
@@ -645,7 +690,7 @@ export default function Page() {
   // Pre-hydration: show nothing interactive
   if (!hasMounted) {
     return (
-      <div className={pageContainer}>
+      <div className={growthContainer}>
         <h1 className={titleBar.title}>Growth Agent</h1>
         <p className={infoBox}>Loading...</p>
       </div>
@@ -655,7 +700,7 @@ export default function Page() {
   // Not connected or still reconnecting
   if (status !== "connected") {
     return (
-      <div className={pageContainer}>
+      <div className={growthContainer}>
         <h1 className={titleBar.title}>Growth Agent</h1>
         <div className={infoBox}>
           <p>Connect your wallet to manage drafts.</p>
@@ -676,7 +721,7 @@ export default function Page() {
   // Wrong address
   if (!isOwner) {
     return (
-      <div className={pageContainer}>
+      <div className={growthContainer}>
         <h1 className={titleBar.title}>Growth Agent</h1>
         <p className={infoBox}>This page is restricted to the site owner.</p>
       </div>
@@ -694,7 +739,7 @@ export default function Page() {
   const showActions = tab === "drafts" || tab === "approved";
 
   return (
-    <div className={pageContainer}>
+    <div className={growthContainer}>
       <h1 className={titleBar.title}>Growth Agent</h1>
 
       <InsightsSection insights={insights ?? null} />
@@ -723,70 +768,35 @@ export default function Page() {
               pageGroups.map((group) => {
                 const eng = group.totalEngagement;
                 const hasEngagement = eng.favourites + eng.reblogs + eng.replies > 0;
-                let displayUrl = group.url;
-                try {
-                  displayUrl = new URL(group.url).pathname;
-                } catch {
-                  /* keep full url */
-                }
                 return (
                   <details key={group.url} className={pageGroupRow}>
-                    <summary
-                      style={{
-                        cursor: "pointer",
-                        padding: "10px 12px",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
-                        flexWrap: "wrap",
-                      }}
-                    >
+                    <summary className={pageGroupSummaryRow}>
                       <a
                         href={group.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        style={{
-                          color: "#2563eb",
-                          textDecoration: "underline",
-                          fontSize: "14px",
-                          fontWeight: 500,
-                          flex: 1,
-                          minWidth: 0,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
+                        className={pageGroupLink}
                         onClick={(e) => e.stopPropagation()}
                       >
-                        {displayUrl}
+                        {group.displayUrl}
                       </a>
-                      <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>
-                        {group.drafts.length}×
-                      </span>
+                      <span className={pageGroupMeta}>{group.drafts.length}×</span>
                       {group.lastPublished && (
-                        <span style={{ fontSize: "12px", color: "#777", whiteSpace: "nowrap" }}>
-                          {new Date(group.lastPublished).toLocaleDateString()}
-                        </span>
+                        <span className={pageGroupDim}>{new Date(group.lastPublished).toLocaleDateString()}</span>
                       )}
-                      <span style={{ whiteSpace: "nowrap" }}>
+                      <span className={pageGroupDim}>
                         {[...group.channels].map((ch) => (ch === "mastodon" ? "🐘" : "🦋")).join(" ")}
                       </span>
                       {hasEngagement && (
-                        <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>
+                        <span className={pageGroupMeta}>
                           ❤️ {eng.favourites} 🔁 {eng.reblogs} 💬 {eng.replies}
                         </span>
                       )}
-                      <span
-                        style={{
-                          fontSize: "12px",
-                          color: group.pageviews !== null ? "#555" : "#aaa",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
+                      <span className={group.pageviews !== null ? pageGroupMeta : pageGroupDim}>
                         {group.pageviews !== null ? `${group.pageviews} views (28d)` : "—"}
                       </span>
                     </summary>
-                    <div style={{ borderTop: "1px solid #e5e7eb", padding: "8px 12px" }}>
+                    <div className={pageGroupBody}>
                       {group.drafts.map((draft) => (
                         <DraftCardView
                           key={draft.id}
@@ -813,7 +823,7 @@ export default function Page() {
                 key={draft.id}
                 draft={draft}
                 showActions={showActions}
-                history={historyByPage[draft.source_blog_post ?? ""] ?? []}
+                history={historyByPage[draft.link ?? draft.source_blog_post ?? ""] ?? []}
                 metrics={metricsByDraftId[draft.id]}
                 onApprove={handleApprove}
                 onReject={handleReject}

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -2,6 +2,8 @@ import React, { useState, useMemo } from "react";
 import { useIsMounted } from "../../hooks/useIsMounted";
 import { useAccount, useConnect } from "wagmi";
 import { css } from "../../styled-system/css";
+import { pageContainer, titleBar, tabs as tabStyles } from "../../layouts/styles";
+import { Tab } from "../../components/Tab";
 import {
   useGrowthDrafts,
   useGrowthInsights,
@@ -17,19 +19,6 @@ type Tab = "drafts" | "approved" | "published" | "rejected";
 
 // ===== Styles =====
 
-const pageContainer = css({
-  maxWidth: "900px",
-  mx: "auto",
-  px: "md",
-  py: "lg",
-});
-
-const pageTitle = css({
-  fontSize: "2xl",
-  fontWeight: "bold",
-  mb: "lg",
-  color: "text",
-});
 
 const infoBox = css({
   padding: "lg",
@@ -38,38 +27,6 @@ const infoBox = css({
   fontSize: "md",
 });
 
-const tabBar = css({
-  display: "flex",
-  gap: "xs",
-  mb: "lg",
-  flexWrap: "wrap",
-});
-
-const tabButton = css({
-  padding: "sm md",
-  border: "1px solid",
-  borderColor: "gray.300",
-  borderRadius: "sm",
-  backgroundColor: "transparent",
-  cursor: "pointer",
-  fontSize: "sm",
-  fontWeight: "medium",
-  transition: "all 0.2s",
-  color: "gray.700",
-  _hover: { backgroundColor: "gray.100" },
-});
-
-const tabButtonActive = css({
-  padding: "sm md",
-  border: "1px solid",
-  borderColor: "gray.600",
-  borderRadius: "sm",
-  backgroundColor: "gray.200",
-  cursor: "pointer",
-  fontSize: "sm",
-  fontWeight: "medium",
-  color: "gray.900",
-});
 
 const draftCard = css({
   border: "1px solid",
@@ -274,10 +231,8 @@ const loadingText = css({
 });
 
 const insightsPanel = css({
-  mt: "xl",
-  borderTop: "1px solid",
-  borderColor: "gray.200",
-  pt: "md",
+  mt: "sm",
+  mb: "md",
 });
 
 const insightsList = css({
@@ -688,7 +643,7 @@ export default function Page() {
   if (!hasMounted) {
     return (
       <div className={pageContainer}>
-        <h1 className={pageTitle}>Growth Agent</h1>
+        <h1 className={titleBar.title}>Growth Agent</h1>
         <p className={infoBox}>Loading...</p>
       </div>
     );
@@ -698,7 +653,7 @@ export default function Page() {
   if (status !== "connected") {
     return (
       <div className={pageContainer}>
-        <h1 className={pageTitle}>Growth Agent</h1>
+        <h1 className={titleBar.title}>Growth Agent</h1>
         <div className={infoBox}>
           <p>Connect your wallet to manage drafts.</p>
           {connectors.length > 0 && (
@@ -719,13 +674,13 @@ export default function Page() {
   if (!isOwner) {
     return (
       <div className={pageContainer}>
-        <h1 className={pageTitle}>Growth Agent</h1>
+        <h1 className={titleBar.title}>Growth Agent</h1>
         <p className={infoBox}>This page is restricted to the site owner.</p>
       </div>
     );
   }
 
-  const tabs: { key: Tab; label: string; count: number }[] = [
+  const tabDefs: { key: Tab; label: string; count: number }[] = [
     { key: "drafts", label: "Pending", count: queue?.drafts.length ?? 0 },
     { key: "approved", label: "Approved", count: queue?.approved.length ?? 0 },
     { key: "published", label: "Published", count: queue?.published.length ?? 0 },
@@ -737,7 +692,7 @@ export default function Page() {
 
   return (
     <div className={pageContainer}>
-      <h1 className={pageTitle}>Growth Agent</h1>
+      <h1 className={titleBar.title}>Growth Agent</h1>
 
       <InsightsSection insights={insights ?? null} />
 
@@ -747,15 +702,14 @@ export default function Page() {
         <p className={loadingText}>Loading drafts...</p>
       ) : (
         <>
-          <div className={tabBar}>
-            {tabs.map((t) => (
-              <button
+          <div className={tabStyles.tabList}>
+            {tabDefs.map((t) => (
+              <Tab
                 key={t.key}
-                className={tab === t.key ? tabButtonActive : tabButton}
+                label={`${t.label} (${t.count})`}
+                isActive={tab === t.key}
                 onClick={() => handleTabChange(t.key)}
-              >
-                {t.label} ({t.count})
-              </button>
+              />
             ))}
           </div>
 

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -739,6 +739,8 @@ export default function Page() {
     <div className={pageContainer}>
       <h1 className={pageTitle}>Growth Agent</h1>
 
+      <InsightsSection insights={insights ?? null} />
+
       {error && <div className={errorBanner}>{error}</div>}
 
       {loadingDrafts ? (
@@ -833,7 +835,6 @@ export default function Page() {
             ))
           )}
 
-          <InsightsSection insights={insights ?? null} />
         </>
       )}
     </div>

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from "react";
 import { useIsMounted } from "../../hooks/useIsMounted";
 import { useAccount, useConnect } from "wagmi";
 import { css } from "../../styled-system/css";
-import { pageContainer, titleBar, tabs as tabStyles } from "../../layouts/styles";
+import { titleBar, tabs as tabStyles } from "../../layouts/styles";
 import { Tab } from "../../components/Tab";
 import {
   useGrowthDrafts,
@@ -19,14 +19,12 @@ type Tab = "drafts" | "approved" | "published" | "rejected";
 
 // ===== Styles =====
 
-
 const infoBox = css({
   padding: "lg",
   textAlign: "center",
   color: "gray.600",
   fontSize: "md",
 });
-
 
 const draftCard = css({
   border: "1px solid",
@@ -578,20 +576,27 @@ export default function Page() {
       trafficByPath.set(p.x as string, p.y as number);
     }
 
-    const map = new Map<string, {
-      url: string;
-      drafts: Draft[];
-      totalEngagement: { favourites: number; reblogs: number; replies: number };
-      lastPublished: string | null;
-      channels: Set<string>;
-      pageviews: number | null;
-    }>();
+    const map = new Map<
+      string,
+      {
+        url: string;
+        drafts: Draft[];
+        totalEngagement: { favourites: number; reblogs: number; replies: number };
+        lastPublished: string | null;
+        channels: Set<string>;
+        pageviews: number | null;
+      }
+    >();
 
     for (const draft of queue?.published ?? []) {
       const url = draft.link ?? draft.source_blog_post ?? "(no link)";
       if (!map.has(url)) {
         let path: string | null = null;
-        try { path = new URL(url).pathname; } catch { /* invalid url */ }
+        try {
+          path = new URL(url).pathname;
+        } catch {
+          /* invalid url */
+        }
         map.set(url, {
           url,
           drafts: [],
@@ -615,9 +620,7 @@ export default function Page() {
       }
     }
 
-    return [...map.values()].sort((a, b) =>
-      (b.lastPublished ?? "").localeCompare(a.lastPublished ?? "")
-    );
+    return [...map.values()].sort((a, b) => (b.lastPublished ?? "").localeCompare(a.lastPublished ?? ""));
   }, [queue?.published, insights?.website_analytics?.top_pages, metricsByDraftId]);
 
   const handleApprove = async (id: string, scheduledAt?: string, reviewComment?: string) => {
@@ -721,34 +724,65 @@ export default function Page() {
                 const eng = group.totalEngagement;
                 const hasEngagement = eng.favourites + eng.reblogs + eng.replies > 0;
                 let displayUrl = group.url;
-                try { displayUrl = new URL(group.url).pathname; } catch { /* keep full url */ }
+                try {
+                  displayUrl = new URL(group.url).pathname;
+                } catch {
+                  /* keep full url */
+                }
                 return (
                   <details key={group.url} className={pageGroupRow}>
-                    <summary style={{ cursor: "pointer", padding: "10px 12px", display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                    <summary
+                      style={{
+                        cursor: "pointer",
+                        padding: "10px 12px",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        flexWrap: "wrap",
+                      }}
+                    >
                       <a
                         href={group.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        style={{ color: "#2563eb", textDecoration: "underline", fontSize: "14px", fontWeight: 500, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                        style={{
+                          color: "#2563eb",
+                          textDecoration: "underline",
+                          fontSize: "14px",
+                          fontWeight: 500,
+                          flex: 1,
+                          minWidth: 0,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
                         onClick={(e) => e.stopPropagation()}
                       >
                         {displayUrl}
                       </a>
-                      <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>{group.drafts.length}×</span>
+                      <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>
+                        {group.drafts.length}×
+                      </span>
                       {group.lastPublished && (
                         <span style={{ fontSize: "12px", color: "#777", whiteSpace: "nowrap" }}>
                           {new Date(group.lastPublished).toLocaleDateString()}
                         </span>
                       )}
                       <span style={{ whiteSpace: "nowrap" }}>
-                        {[...group.channels].map((ch) => ch === "mastodon" ? "🐘" : "🦋").join(" ")}
+                        {[...group.channels].map((ch) => (ch === "mastodon" ? "🐘" : "🦋")).join(" ")}
                       </span>
                       {hasEngagement && (
                         <span style={{ fontSize: "12px", color: "#555", whiteSpace: "nowrap" }}>
                           ❤️ {eng.favourites} 🔁 {eng.reblogs} 💬 {eng.replies}
                         </span>
                       )}
-                      <span style={{ fontSize: "12px", color: group.pageviews !== null ? "#555" : "#aaa", whiteSpace: "nowrap" }}>
+                      <span
+                        style={{
+                          fontSize: "12px",
+                          color: group.pageviews !== null ? "#555" : "#aaa",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
                         {group.pageviews !== null ? `${group.pageviews} views (28d)` : "—"}
                       </span>
                     </summary>
@@ -788,7 +822,6 @@ export default function Page() {
               />
             ))
           )}
-
         </>
       )}
     </div>

--- a/website/pages/growth/+Page.tsx
+++ b/website/pages/growth/+Page.tsx
@@ -5,11 +5,12 @@ import { css } from "../../styled-system/css";
 import {
   useGrowthDrafts,
   useGrowthInsights,
+  useGrowthPerformance,
   useApproveDraft,
   useRejectDraft,
   useUpdateDraft,
 } from "../../hooks/useGrowthApi";
-import { CHANNEL_CHAR_LIMITS, type Draft, type Insights } from "../../types/growth";
+import { CHANNEL_CHAR_LIMITS, type Draft, type Insights, type PostMetrics } from "../../types/growth";
 import { OWNER_ADDRESS } from "../../utils/getChain";
 
 type Tab = "drafts" | "approved" | "published" | "rejected";
@@ -312,6 +313,7 @@ function DraftCardView({
   draft,
   showActions,
   history,
+  metrics,
   onApprove,
   onReject,
   onUpdate,
@@ -320,6 +322,7 @@ function DraftCardView({
   draft: Draft;
   showActions: boolean;
   history: Draft[];
+  metrics?: PostMetrics;
   onApprove: (id: string, scheduledAt?: string, reviewComment?: string) => Promise<void>;
   onReject: (id: string, reviewComment?: string) => Promise<void>;
   onUpdate: (id: string, body: Partial<Draft>) => Promise<void>;
@@ -462,6 +465,11 @@ function DraftCardView({
               {draft.review_comment ? `\nComment: ${draft.review_comment}` : ""}
             </div>
           )}
+          {metrics && (
+            <div style={{ fontSize: "13px", color: "#666", margin: "6px 0" }}>
+              ❤️ {metrics.favourites} &nbsp; 🔁 {metrics.reblogs} &nbsp; 💬 {metrics.replies}
+            </div>
+          )}
           {showActions && (
             <>
               <textarea
@@ -566,6 +574,7 @@ export default function Page() {
 
   const { data: queue, isPending: loadingDrafts, error: draftsError } = useGrowthDrafts(isOwner);
   const { data: insights } = useGrowthInsights(isOwner);
+  const { data: performance } = useGrowthPerformance(isOwner);
 
   const approveMutation = useApproveDraft();
   const rejectMutation = useRejectDraft();
@@ -590,6 +599,14 @@ export default function Page() {
     }
     return map;
   }, [queue?.published]);
+
+  const metricsByDraftId = useMemo(() => {
+    const map: Record<string, PostMetrics> = {};
+    for (const m of performance?.posts ?? []) {
+      map[m.id] = m;
+    }
+    return map;
+  }, [performance?.posts]);
 
   const handleApprove = async (id: string, scheduledAt?: string, reviewComment?: string) => {
     await approveMutation.mutateAsync({ id, scheduledAt, reviewComment });
@@ -692,6 +709,7 @@ export default function Page() {
                 draft={draft}
                 showActions={showActions}
                 history={historyByPage[draft.source_blog_post ?? ""] ?? []}
+                metrics={metricsByDraftId[draft.id]}
                 onApprove={handleApprove}
                 onReject={handleReject}
                 onUpdate={handleUpdate}

--- a/website/test/GrowthPage.test.tsx
+++ b/website/test/GrowthPage.test.tsx
@@ -19,6 +19,7 @@ let mockApproveError: Error | null = null;
 vi.mock("../hooks/useGrowthApi", () => ({
   useGrowthDrafts: (...args: unknown[]) => mockUseGrowthDrafts(...args),
   useGrowthInsights: (...args: unknown[]) => mockUseGrowthInsights(...args),
+  useGrowthPerformance: () => ({ data: undefined, isPending: false }),
   useApproveDraft: () => ({
     mutateAsync: mockApproveMutateAsync,
     isPending: false,


### PR DESCRIPTION
# Growth Agent: Engagement Metrics + UI Overhaul

## Summary

- **Per-post engagement metrics** collected from Mastodon and Bluesky on every daily ingest run and surfaced in the Growth UI
- **Published tab redesigned** as a page-centric view: posts are grouped by the blog page they promote, with 28-day traffic data from Umami alongside social engagement counts
- **Growth UI aligned with site styles**: shared title, tab component, and container styles; Insights panel moved above the tabs; Growth nav link visible only to the authenticated owner
- **Test coverage added** for the new metrics collection function

## What changed

### `growth-agent/`

**`agent/models.py`** — Two new Pydantic models:
- `PostMetrics` — per-post engagement: reblogs, favourites, replies, plus stub fields for future Umami UTM correlation
- `Performance` — container for a list of `PostMetrics`

**`agent/nodes/ingest.py`**
- `_collect_post_metrics()` added: called at the end of every ingest run, reads `content_queue.json`, fetches live engagement counts from Mastodon (`GET /api/v1/statuses/:id`) and Bluesky (`app.bsky.feed.getPosts` in batches of 25), writes `performance.json` to S3
- Umami fetch window extended from 7 days to 28 days so traffic data is meaningful even with infrequent posting
- Errors on individual posts are swallowed; the rest still write

**`agent/platforms/mastodon.py`** — `get_status(status_id)` method added

**`agent/platforms/bluesky.py`** — `get_posts(uris)` method added; fetches known AT URIs directly in batches of 25, avoiding the feed-based approach that was polluted by reposts and capped at 100 items

**`test/test_handler.py`** — Four new tests for `_collect_post_metrics`:
- Mastodon happy path
- Bluesky happy path (mocking `get_posts`)
- Empty published queue → writes empty performance.json
- Per-post API failure → skips that post gracefully, does not raise

**`notebooks/01_umami_ingest.ipynb`** — Section 8 added: copies prod `content_queue.json` into the dev prefix, runs `_collect_post_metrics`, displays results — allows testing the full metrics pipeline locally against real social API data without touching prod state

### `website/`

**`hooks/useGrowthApi.ts`** — `useGrowthPerformance()` hook added; fetches `performance.json` via the existing authenticated `apiFetch` helper

**`pages/growth/+Page.tsx`**
- Published tab replaced with a page-grouped collapsible list: each row is one blog page, showing promotion count, last promoted date, channels (🐘/🦋), total engagement, and 28-day pageviews from Umami; clicking expands the individual post cards
- Pageviews joined client-side by matching `draft.link` pathname against `insights.website_analytics.top_pages[].x`
- Insights & Analytics section moved above the tab bar
- Local style re-definitions removed; now uses shared `pageContainer`, `titleBar.title`, and `Tab` component from `layouts/styles`
- Local `tabs` array renamed `tabDefs` to avoid collision with the imported tab styles

**`layouts/LayoutDefault.tsx`** — `GrowthNavLink` component added: shows a Growth link in the top nav, but only after client-side hydration confirms the owner wallet is connected

## Testing

```bash
# Python
cd growth-agent && uv run pytest test/test_handler.py -q

# After refreshing prod analytics (28-day window):
uv run python run_local.py --analytics --prod

# Frontend
cd website && npm run dev   # check /growth
```
