### PR TITLE
Threat model refined

### DIFF
--- a/.github/CVE_TRIAGE.md
+++ b/.github/CVE_TRIAGE.md
@@ -92,6 +92,8 @@ Only needed when tier alone is not enough (T1/T2 alerts, or a T3 alert with inte
 
 When assessing impact, ask: "Could this allow an attacker to corrupt on-chain state, redirect USDC, or tamper with NFT metadata?" If yes → treat as highest priority regardless of tier.
 
+**Reachability shortcut:** when a CVE's CWE or category maps onto a row in [THREAT_MODEL.md §5 Attack Techniques](THREAT_MODEL.md#5-attack-techniques-by-surface), use that row's surface and status to judge reachability faster — e.g. a CVE matching a technique already marked *mitigated* or *accepted* on its only reachable surface defers.
+
 ---
 
 ## Worked Example — `ws` (HIGH) in x402_facilitator

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -2,6 +2,15 @@
 
 Last updated: 2026-06-20
 
+This is a lightweight, living threat model. It follows the OWASP four-question framework and the values of the Threat Modeling Manifesto — a maintained document over a one-time audit, design issues over checkbox compliance, action over ceremony.
+
+| Question | Answered in |
+|---|---|
+| What are we working on? | §1 Assets · §4 Trust Boundaries |
+| What can go wrong? | §2 Blast Radius · §3 Threat Actors · §5 Attack Techniques |
+| What are we going to do about it? | §7 Component Findings · §8 Mitigations |
+| Did we do a good enough job? | §8 Review Cadence |
+
 ---
 
 ## 1. Assets
@@ -24,25 +33,42 @@ Notably absent: user wallet keys (never touch the server), user PII (not collect
 
 ---
 
-## 2. Threat Actors
+## 2. Blast Radius
 
-Realistic adversaries for a project of this scale, ordered by capability:
+If a component is fully compromised, what else falls with it:
 
-| Actor | Capability | Motivation | Likely vector |
+| Component | Direct impact | Cascades to |
+|---|---|---|
+| **Owner EOA** | Malicious upgrade to all 5 contracts | Complete ETH drain from GenImNFTv4 + LLMv1; all NFT URIs replaceable; USDC fee wallet redirectable — total system compromise. Key is now a dedicated EOA (not daily wallet); full mitigation requires Gnosis Safe. |
+| **Agent wallet** (scw_js) | `requestImageUpdate()` callable arbitrarily; drains GenImNFTv4 at `mintPrice` per call | NFT metadata corruption for all tokens; contract ETH drained |
+| **Facilitator wallet** | USDC fees redirected | Financial only; no access to user funds or upgrade paths |
+| **SCW_SECRET_KEY** | S3 bucket writable; email notifications spoofable | Generated images replaceable; no on-chain impact |
+| **BFL / IONOS key** | Image generation quota consumed | No on-chain or financial impact to users |
+| **x402_facilitator service** | Payment settlements halt | Image generation feature unavailable; already-signed USDC authorizations expire unused |
+| **LLMv1 authorized provider** | Can submit fraudulent Merkle batches; drains user balances up to available ETH | Only affects LLMv1 user balances; no access to other contracts |
+
+Key observation: the **owner EOA** is the single point of catastrophic failure. All other compromises are bounded in scope. This makes key management the highest-priority operational security concern, ahead of any code-level finding.
+
+---
+
+## 3. Threat Actors
+
+Realistic adversaries for a project of this scale, ordered by capability. Each entry describes WHO the actor is — their role, access level, and motivation. Attack methods and vectors are documented in §4 Trust Boundaries and `eth/SECURITY.md`.
+
+| Actor | Capability | Motivation | Primary access |
 |---|---|---|---|
-| **Opportunistic bot** | Low — runs known exploit scripts | Financial: drain any available funds | Scans for common Solidity patterns (no-auth functions, reentrancy) |
-| **Malicious buyer/collector** | Medium — reads the deployed contract ABI | Financial: mint at below-market price, extract ETH | Crafts a receiver contract to exploit ERC721 callbacks |
-| **Phishing / cross-origin site** | Medium — operates a malicious web page | Financial: trigger payment flows without user intent | Exploits open CORS on the facilitator from a different origin |
-| **Compromised service provider** | High — already has partial on-chain trust | Financial or sabotage | Abuses `authorizedProviders` role in LLMv1 to submit fraudulent batches |
-| **Key compromise** | Critical — attacker holds the owner EOA | Total control | Phishing, leaked `.env`, compromised dev machine |
+| **Opportunistic bot** | Low — runs known exploit scripts | Financial: drain any available ETH | Public contract ABI; scans for common Solidity patterns (no-auth functions, reentrancy) |
+| **Financially motivated attacker** | Medium — reads deployed ABIs, may operate a malicious website | Financial: extract ETH, redirect USDC, mint below-market | Direct contract calls; crafted ERC721 receiver contracts; cross-origin requests to x402_facilitator |
+| **Insider / compromised authorized account** | High — already holds partial on-chain trust or serverless secrets | Financial gain or sabotage | `authorizedProviders` role in LLMv1; SCW_SECRET_KEY or agent wallet obtained via credential leak |
+| **Attacker with owner credentials** | Critical — holds the owner EOA or agent wallet key | Total control | Key obtained via phishing, leaked `.env`, or compromised dev machine |
 
 Out of scope: nation-state actors, L1/L2 consensus attacks, Scaleway infrastructure compromise, wallet software vulnerabilities.
 
 ---
 
-## 3. Trust Boundaries
+## 4. Trust Boundaries
 
-Where control or trust changes hands. Each arrow is a potential attack surface.
+This is the attack-**surface** map: each arrow marks where data crosses from a less-trusted zone into a more-trusted one. Read it against §3 — an attack path is an actor reaching one of these arrows. The boundaries most exposed to untrusted callers are starred (★); the owner-EOA boundary carries no external surface but the highest blast radius (§2).
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -77,27 +103,39 @@ Owner EOA ───────────────────────�
 
 ---
 
-## 4. Blast Radius
+## 5. Attack Techniques by Surface
 
-If a component is fully compromised, what else falls with it:
+This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete classes of weakness in scope when reviewing or scanning this system. Only *live* categories are listed — a category's absence means it was considered and judged not applicable, not overlooked. Detailed, per-instance findings live in the documents named in the **Tracked in** column. The two halves of the system map to two standard catalogs:
 
-| Component | Direct impact | Cascades to |
-|---|---|---|
-| **Owner EOA** | Malicious upgrade to all 5 contracts | Complete ETH drain from GenImNFTv4 + LLMv1; all NFT URIs replaceable; USDC fee wallet redirectable — total system compromise. Key is now a dedicated EOA (not daily wallet); full mitigation requires Gnosis Safe. |
-| **Agent wallet** (scw_js) | `requestImageUpdate()` callable arbitrarily; drains GenImNFTv4 at `mintPrice` per call | NFT metadata corruption for all tokens; contract ETH drained |
-| **Facilitator wallet** | USDC fees redirected | Financial only; no access to user funds or upgrade paths |
-| **SCW_SECRET_KEY** | S3 bucket writable; email notifications spoofable | Generated images replaceable; no on-chain impact |
-| **BFL / IONOS key** | Image generation quota consumed | No on-chain or financial impact to users |
-| **x402_facilitator service** | Payment settlements halt | Image generation feature unavailable; already-signed USDC authorizations expire unused |
-| **LLMv1 authorized provider** | Can submit fraudulent Merkle batches; drains user balances up to available ETH | Only affects LLMv1 user balances; no access to other contracts |
+- [OWASP Smart Contract Top 10 (2025)](https://owasp.org/www-project-smart-contract-top-10/) — for `eth/` contracts.
+- [OWASP API Security Top 10 (2023)](https://owasp.org/API-Security/editions/2023/en/0x11-t10/) — for the serverless functions and website.
 
-Key observation: the **owner EOA** is the single point of catastrophic failure. All other compromises are bounded in scope. This makes key management the highest-priority operational security concern, ahead of any code-level finding.
+### Contract layer — OWASP Smart Contract Top 10
+
+| Technique (OWASP) | Where it applies | Status | Tracked in |
+|---|---|---|---|
+| Access control (SC01) | `requestImageUpdate` agent whitelist; single-EOA upgrade governance | Mitigated / partially (governance open) | eth/SECURITY.md; §2 |
+| Reentrancy (SC05) | CollectorNFT `_safeMint` price manipulation; SupportV2 donate paths | Open (price-only, no fund theft) / mitigated via `ReentrancyGuardTransient` | eth/SECURITY.md |
+| Logic errors (SC03) | LLMv1 `processBatch` CEI ordering | Accepted (informational, not exploitable) | eth/SECURITY.md |
+| Unchecked external calls (SC06) | SupportV2 arbitrary `_token` in `donateToken` | Accepted (contract holds no funds) | eth/SECURITY.md |
+| Signature replay | LLMv1 Merkle batch submission | Mitigated via `processedBatches` mapping | eth/SECURITY.md |
+| Integer over/underflow (SC08) | All contracts | Mitigated (Solidity 0.8.27 built-in checks) | eth/SECURITY.md |
+
+### API / serverless layer — OWASP API Security Top 10
+
+| Technique (OWASP) | Where it applies | Status | Tracked in |
+|---|---|---|---|
+| Broken authentication (API2) | EIP-712/EIP-3009 sig verify (facilitator); agent-wallet whitelist (scw_js); `useWalletAuth` owner-sig bearer (growth); origin whitelist (comment_service) | Mitigated | §4; §7 |
+| Broken function-level authz (API5) | x402 `Access-Control-Allow-Origin: *`; bounded by EIP-3009 crypto | Accepted (intentional open protocol) | §4 ★; §7 |
+| Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts | Accepted (negligible L2 gas, no attacker incentive) | §4; §7 |
+| Security misconfiguration / secret exposure (API8) | SCW_SECRET_KEY in email headers | Open (medium) | §7 |
+| Unsafe client trust (API10) | Client-side-only image validation | Open (low) | §7 |
 
 ---
 
-## 5. CIA Summary
+## 6. CIA Summary
 
-For blockchain systems, **Integrity** dominates. Confidentiality is generally low concern (code is public, transactions are public). Availability is partially guaranteed by the L2 itself; the serverless layer is the availability risk.
+For blockchain systems, **Integrity** dominates. Confidentiality is generally low concern (code is public, transactions are public). Availability is partially guaranteed by the L2 itself; the serverless layer is the availability risk. **Repudiation** is a structural strength: all on-chain transactions are cryptographically signed and permanently recorded — no actor can deny having submitted a transaction.
 
 | Component | Confidentiality | Integrity | Availability | Notes |
 |---|---|---|---|---|
@@ -109,7 +147,7 @@ For blockchain systems, **Integrity** dominates. Confidentiality is generally lo
 
 ---
 
-## 6. Component Security Findings
+## 7. Component Security Findings
 
 Detailed code-level findings live alongside the code they describe:
 
@@ -117,3 +155,20 @@ Detailed code-level findings live alongside the code they describe:
 |---|---|---|
 | Smart contracts | [eth/SECURITY.md](../eth/SECURITY.md) | CollectorNFT price manipulation (medium), single-owner upgrade path (medium governance) |
 | Serverless & frontend | — | x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), SCW_SECRET_KEY in email headers (medium), client-side-only image validation (low) |
+
+---
+
+## 8. Mitigations and Review Cadence
+
+Active mitigations and where they live:
+
+| Area | Document | What it covers |
+|---|---|---|
+| Contract-level findings | [eth/SECURITY.md](../eth/SECURITY.md) | Open issues, known vulnerabilities, fixed CVEs |
+| Dependency CVEs | [CVE_TRIAGE.md](CVE_TRIAGE.md) | Threat-model-driven triage framework for Dependabot alerts; `/cve-triage` skill operationalizes it |
+
+**Review triggers** — revisit this document when any of the following occur:
+- A contract is upgraded or a new contract is deployed
+- A key is rotated or a new privileged account is added
+- A new serverless function or trust boundary is introduced
+- A CVE is triaged as T1 or T2 (patch required)

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -117,7 +117,7 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 |---|---|---|---|
 | Access control (SC01) | `requestImageUpdate` agent whitelist; single-EOA upgrade governance | Mitigated / partially (governance open) | eth/SECURITY.md; §2 |
 | Reentrancy (SC05) | CollectorNFT `_safeMint` price manipulation; SupportV2 donate paths | Open (price-only, no fund theft) / mitigated via `ReentrancyGuardTransient` | eth/SECURITY.md |
-| Logic errors (SC03) | LLMv1 `processBatch` CEI ordering | Accepted (informational, not exploitable) | eth/SECURITY.md |
+| Logic errors (SC03) | LLMv1 `processBatch` CEI ordering | Low — Open; reentrancy hardening on next upgrade | eth/SECURITY.md |
 | Unchecked external calls (SC06) | SupportV2 arbitrary `_token` in `donateToken` | Accepted (contract holds no funds) | eth/SECURITY.md |
 | Signature replay | LLMv1 Merkle batch submission | Mitigated via `processedBatches` mapping | eth/SECURITY.md |
 | Access control / fund redirection (SC01) | EIP3009 Splitter `executeSplit`; `onlyOwner` `setFacilitatorWallet`/upgrade — **testnet-stage** | Mitigated (testnet): relayer cannot redirect funds — `nonce = keccak256(seller, salt)` binds seller to the buyer signature; owner powers are the residual risk | eth/contracts/EIP3009SplitterV1.sol; §8 |
@@ -129,7 +129,8 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 |---|---|---|---|
 | Broken authentication (API2) | EIP-712/EIP-3009 sig verify (facilitator); agent-wallet whitelist (scw_js); `useWalletAuth` owner-sig bearer (growth); origin whitelist (comment_service) | Mitigated | §4; §7 |
 | Broken function-level authz (API5) | x402 `Access-Control-Allow-Origin: *`; bounded by EIP-3009 crypto | Accepted (intentional open protocol) | §4 ★; §7 |
-| Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts | Accepted (negligible L2 gas, no attacker incentive) | §4; §7 |
+| Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts (accepted); LLM settlement-batch stall (Open, medium) | Mixed — gas drain accepted; batch-stall open | §4; scw_js/SECURITY.md |
+| Unrestricted access to sensitive business flows (API6) | Deliver-before-payment in the LLM and genimg flows | Open (medium) | scw_js/SECURITY.md |
 | Security misconfiguration / secret exposure (API8) | comment_service sends `SCW_SECRET_KEY` as the `X-Auth-Token` header to the Scaleway transactional-email API | Open (medium) | §7 |
 | Unsafe client trust (API10) | Client-side-only image validation | Open (low) | §7 |
 
@@ -156,7 +157,7 @@ Detailed code-level findings live alongside the code they describe:
 | Component | Findings document | Open issues |
 |---|---|---|
 | Smart contracts | [eth/SECURITY.md](../eth/SECURITY.md) | CollectorNFT price manipulation (medium), single-owner upgrade path (medium governance) |
-| Serverless & frontend | — | x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), comment_service sends `SCW_SECRET_KEY` as the email API `X-Auth-Token` header (medium), client-side-only image validation (low) |
+| Serverless & frontend | [scw_js/SECURITY.md](../scw_js/SECURITY.md) | LLM balance-gate (medium) and genimg deliver-before-settle (medium) — see scw_js/SECURITY.md; x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), comment_service sends `SCW_SECRET_KEY` as the email API `X-Auth-Token` header (medium), client-side-only image validation (low) |
 
 ---
 
@@ -167,6 +168,7 @@ Active mitigations and where they live:
 | Area | Document | What it covers |
 |---|---|---|
 | Contract-level findings | [eth/SECURITY.md](../eth/SECURITY.md) | Open issues, known vulnerabilities, fixed CVEs |
+| Serverless findings | [scw_js/SECURITY.md](../scw_js/SECURITY.md) | Open serverless issues (rough; full detail tracked privately via GHSA) |
 | Dependency CVEs | [CVE_TRIAGE.md](CVE_TRIAGE.md) | Threat-model-driven triage framework for Dependabot alerts; `/cve-triage` skill operationalizes it |
 
 **Review triggers** — revisit this document when any of the following occur:

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -54,7 +54,7 @@ Key observation: the **owner EOA** is the single point of catastrophic failure. 
 
 ## 3. Threat Actors
 
-Realistic adversaries for a project of this scale, ordered by capability. Each entry describes WHO the actor is — their role, access level, and motivation. Attack methods and vectors are documented in §4 Trust Boundaries and `eth/SECURITY.md`.
+Realistic adversaries for a project of this scale, ordered by capability. Each entry describes WHO the actor is — their role, access level, and motivation. Attack methods and vectors are documented in §4 Trust Boundaries, §5 Attack Techniques, and `eth/SECURITY.md`.
 
 | Actor | Capability | Motivation | Primary access |
 |---|---|---|---|
@@ -120,7 +120,7 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 | Logic errors (SC03) | LLMv1 `processBatch` CEI ordering | Low — Open; reentrancy hardening on next upgrade | eth/SECURITY.md |
 | Unchecked external calls (SC06) | SupportV2 arbitrary `_token` in `donateToken` | Accepted (contract holds no funds) | eth/SECURITY.md |
 | Signature replay | LLMv1 Merkle batch submission | Mitigated via `processedBatches` mapping | eth/SECURITY.md |
-| Access control / fund redirection (SC01) | EIP3009 Splitter `executeSplit`; `onlyOwner` `setFacilitatorWallet`/upgrade — **testnet-stage** | Mitigated (testnet): relayer cannot redirect funds — `nonce = keccak256(seller, salt)` binds seller to the buyer signature; owner powers are the residual risk | eth/contracts/EIP3009SplitterV1.sol; §8 |
+| Access control / fund redirection (SC01) | EIP3009 Splitter `executeSplit`; `onlyOwner` `setFacilitatorWallet`/upgrade — **testnet-stage** | Mitigated (testnet): relayer cannot redirect funds — `nonce = keccak256(seller, salt)` binds seller to the buyer signature; owner powers are the residual risk | eth/contracts/EIP3009SplitterV1.sol; mainnet promotion → §8 |
 | Integer over/underflow (SC08) | All contracts | Mitigated (Solidity ≥0.8.27 built-in checks; Splitter is 0.8.33) | eth/SECURITY.md |
 
 ### API / serverless layer — OWASP API Security Top 10
@@ -129,7 +129,7 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 |---|---|---|---|
 | Broken authentication (API2) | EIP-712/EIP-3009 sig verify (facilitator); agent-wallet whitelist (scw_js); `useWalletAuth` owner-sig bearer (growth); origin whitelist (comment_service) | Mitigated | §4; §7 |
 | Broken function-level authz (API5) | x402 `Access-Control-Allow-Origin: *`; bounded by EIP-3009 crypto | Accepted (intentional open protocol) | §4 ★; §7 |
-| Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts (accepted); LLM settlement-batch stall (Open, medium) | Mixed — gas drain accepted; batch-stall open | §4; scw_js/SECURITY.md |
+| Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts (accepted); LLM pre-charge balance gate (batch-settlement stall; Open, medium) | Mixed — gas drain accepted; balance-gate open | §4; scw_js/SECURITY.md |
 | Unrestricted access to sensitive business flows (API6) | Deliver-before-payment in the LLM and genimg flows | Open (medium) | scw_js/SECURITY.md |
 | Security misconfiguration / secret exposure (API8) | comment_service sends `SCW_SECRET_KEY` as the `X-Auth-Token` header to the Scaleway transactional-email API | Open (medium) | §7 |
 | Unsafe client trust (API10) | Client-side-only image validation | Open (low) | §7 |
@@ -157,7 +157,7 @@ Detailed code-level findings live alongside the code they describe:
 | Component | Findings document | Open issues |
 |---|---|---|
 | Smart contracts | [eth/SECURITY.md](../eth/SECURITY.md) | CollectorNFT price manipulation (medium), single-owner upgrade path (medium governance) |
-| Serverless & frontend | [scw_js/SECURITY.md](../scw_js/SECURITY.md) | LLM balance-gate (medium) and genimg deliver-before-settle (medium) — see scw_js/SECURITY.md; x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), comment_service sends `SCW_SECRET_KEY` as the email API `X-Auth-Token` header (medium), client-side-only image validation (low) |
+| Serverless & frontend | [scw_js/SECURITY.md](../scw_js/SECURITY.md) | LLM pre-charge balance gate (medium) and genimg deliver-before-settle (medium) — see scw_js/SECURITY.md; x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), comment_service sends `SCW_SECRET_KEY` as the email API `X-Auth-Token` header (medium), client-side-only image validation (low) |
 
 ---
 

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -22,8 +22,9 @@ What has monetary value, irreversibility, or trust significance in this system:
 | ETH in GenImNFTv4 | On-chain | Accumulates mint fees until `withdraw()` is called |
 | ETH in LLMv1 | On-chain | User prepaid balances; withdrawable by users or claimable by providers |
 | USDC settlements | x402_facilitator | Per-request payments routed through the facilitator |
+| EIP3009 Splitter contract (testnet) | On-chain, Optimism Sepolia only (`eip155:11155420`) | Routes USDC settlements via EIP-3009; owner-upgradeable. Not yet on mainnet — promotes to a live asset on mainnet deployment |
 | NFT metadata integrity | On-chain (token URIs) | Authoritative record of what image each token represents |
-| Owner EOA private key | Dedicated keystore account (`0x1af51D…fBB20`), separated from daily wallet since 2026-06 | Controls all five upgradeable contracts — the highest-value key in the system |
+| Owner EOA private key | Dedicated keystore account (`0x1af51D…fBB20`), separated from daily wallet since 2026-06 | Controls every upgradeable contract — the highest-value key in the system |
 | Agent wallet private key | scw_js secrets | Can trigger `requestImageUpdate()` and receive mintPrice per call |
 | Facilitator wallet private key | x402_facilitator secrets | Receives USDC fees from settlements |
 | Scaleway secrets (SCW_SECRET_KEY) | Serverless secrets | Access to S3 image bucket and transactional email |
@@ -39,7 +40,7 @@ If a component is fully compromised, what else falls with it:
 
 | Component | Direct impact | Cascades to |
 |---|---|---|
-| **Owner EOA** | Malicious upgrade to all 5 contracts | Complete ETH drain from GenImNFTv4 + LLMv1; all NFT URIs replaceable; USDC fee wallet redirectable — total system compromise. Key is now a dedicated EOA (not daily wallet); full mitigation requires Gnosis Safe. |
+| **Owner EOA** | Malicious upgrade to every upgradeable contract | Complete ETH drain from GenImNFTv4 + LLMv1; all NFT URIs replaceable; USDC fee wallet redirectable — total system compromise. The EIP3009 Splitter joins this blast radius once deployed to mainnet. Key is now a dedicated EOA (not daily wallet); full mitigation requires Gnosis Safe. |
 | **Agent wallet** (scw_js) | `requestImageUpdate()` callable arbitrarily; drains GenImNFTv4 at `mintPrice` per call | NFT metadata corruption for all tokens; contract ETH drained |
 | **Facilitator wallet** | USDC fees redirected | Financial only; no access to user funds or upgrade paths |
 | **SCW_SECRET_KEY** | S3 bucket writable; email notifications spoofable | Generated images replaceable; no on-chain impact |
@@ -95,7 +96,7 @@ scw_js
   ├─ bearer token ──────────────────────► BFL / IONOS APIs
   └─ AWS SDK ───────────────────────────► Scaleway S3
 
-Owner EOA ───────────────────────────────► All 5 upgradeable contracts
+Owner EOA ───────────────────────────────► Every upgradeable contract
   (single key controls all upgrade paths)
 ```
 
@@ -119,7 +120,8 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 | Logic errors (SC03) | LLMv1 `processBatch` CEI ordering | Accepted (informational, not exploitable) | eth/SECURITY.md |
 | Unchecked external calls (SC06) | SupportV2 arbitrary `_token` in `donateToken` | Accepted (contract holds no funds) | eth/SECURITY.md |
 | Signature replay | LLMv1 Merkle batch submission | Mitigated via `processedBatches` mapping | eth/SECURITY.md |
-| Integer over/underflow (SC08) | All contracts | Mitigated (Solidity 0.8.27 built-in checks) | eth/SECURITY.md |
+| Access control / fund redirection (SC01) | EIP3009 Splitter `executeSplit`; `onlyOwner` `setFacilitatorWallet`/upgrade — **testnet-stage** | Mitigated (testnet): relayer cannot redirect funds — `nonce = keccak256(seller, salt)` binds seller to the buyer signature; owner powers are the residual risk | eth/contracts/EIP3009SplitterV1.sol; §8 |
+| Integer over/underflow (SC08) | All contracts | Mitigated (Solidity ≥0.8.27 built-in checks; Splitter is 0.8.33) | eth/SECURITY.md |
 
 ### API / serverless layer — OWASP API Security Top 10
 
@@ -128,7 +130,7 @@ This is the **HOW** that complements §3 (WHO) and §4 (WHERE): the concrete cla
 | Broken authentication (API2) | EIP-712/EIP-3009 sig verify (facilitator); agent-wallet whitelist (scw_js); `useWalletAuth` owner-sig bearer (growth); origin whitelist (comment_service) | Mitigated | §4; §7 |
 | Broken function-level authz (API5) | x402 `Access-Control-Allow-Origin: *`; bounded by EIP-3009 crypto | Accepted (intentional open protocol) | §4 ★; §7 |
 | Unrestricted resource consumption (API4) | `/settle` spam gas drain; serverless cold starts | Accepted (negligible L2 gas, no attacker incentive) | §4; §7 |
-| Security misconfiguration / secret exposure (API8) | SCW_SECRET_KEY in email headers | Open (medium) | §7 |
+| Security misconfiguration / secret exposure (API8) | comment_service sends `SCW_SECRET_KEY` as the `X-Auth-Token` header to the Scaleway transactional-email API | Open (medium) | §7 |
 | Unsafe client trust (API10) | Client-side-only image validation | Open (low) | §7 |
 
 ---
@@ -143,7 +145,7 @@ For blockchain systems, **Integrity** dominates. Confidentiality is generally lo
 | x402_facilitator | Low | **High** — invalid settlement = wrong payment routing | Medium — serverless cold starts | Open CORS degrades integrity boundary |
 | scw_js | Low | **High** — agent wallet controls on-chain writes | Medium | API key compromise has no on-chain reach |
 | website frontend | Low | Medium — client-side only; no server state | Low — static hosting | Wallet auth is the integrity boundary |
-| comment_service | Medium — user names/text | Low — like counts only | Low | Lowest risk component |
+| comment_service | Medium — stores anonymous user names/text in S3 | Low — comment content and like counts | Low | Low-value, but holds `SCW_SECRET_KEY` (email) — not zero-secret |
 
 ---
 
@@ -154,7 +156,7 @@ Detailed code-level findings live alongside the code they describe:
 | Component | Findings document | Open issues |
 |---|---|---|
 | Smart contracts | [eth/SECURITY.md](../eth/SECURITY.md) | CollectorNFT price manipulation (medium), single-owner upgrade path (medium governance) |
-| Serverless & frontend | — | x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), SCW_SECRET_KEY in email headers (medium), client-side-only image validation (low) |
+| Serverless & frontend | — | x402_facilitator open CORS (intentional; gas-drain risk accepted — negligible on L2, no attacker incentive), comment_service sends `SCW_SECRET_KEY` as the email API `X-Auth-Token` header (medium), client-side-only image validation (low) |
 
 ---
 
@@ -169,6 +171,7 @@ Active mitigations and where they live:
 
 **Review triggers** — revisit this document when any of the following occur:
 - A contract is upgraded or a new contract is deployed
+- The EIP3009 Splitter (or any testnet-stage contract) is deployed to mainnet — promote it to a full asset/blast-radius entry and re-scope the owner blast radius
 - A key is rotated or a new privileged account is added
 - A new serverless function or trust boundary is introduced
 - A CVE is triaged as T1 or T2 (patch required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Blog posts are `.md` or `.mdx` in `website/blog/` with frontmatter (`title`, `pu
 See [`.github/THREAT_MODEL.md`](.github/THREAT_MODEL.md) for full asset inventory, blast radius, and trust boundaries. See [`eth/SECURITY.md`](eth/SECURITY.md) for contract-level findings. Use the **`cve-triage`** skill (`.claude/skills/cve-triage/`) to evaluate open Dependabot alerts against the threat model; triage criteria are in [`.github/CVE_TRIAGE.md`](.github/CVE_TRIAGE.md).
 
 **Key hierarchy** (highest-value first):
-- `CONTRACT_OWNER_PRIVATE_KEY` (Hardhat keystore) — dedicated EOA `0x1af51D…fBB20`, controls all 5 upgradeable contracts. Never use for anything else.
+- `CONTRACT_OWNER_PRIVATE_KEY` (Hardhat keystore) — dedicated EOA `0x1af51D…fBB20`, controls every upgradeable contract. Never use for anything else.
 - `SEPOLIA_PRIVATE_KEY` (Hardhat keystore) — deployment/script signing key `0x073f26…`. Does NOT own contracts.
 - Agent wallet `0xAAEBC1…` — backend-only, whitelisted on GenImNFTv4 via `authorizeAgentWallet()`.
 - Facilitator wallet — stored as Scaleway secret, receives USDC fees only.

--- a/eth/SECURITY.md
+++ b/eth/SECURITY.md
@@ -23,7 +23,7 @@ Unfixed vulnerabilities are tracked privately via GitHub Security Advisories. Th
 | `CollectorNFT.sol` | Reentrancy via `_safeMint` — price manipulation only, no fund theft | Medium | Open — tracked privately |
 | All upgradeable | Upgrade gated by single EOA only, no timelock or multi-sig | Medium (governance) | Partially mitigated — see below |
 | `SupportV2.sol` | Arbitrary `_token` address accepted in `donateToken()` | Low | Accepted — contract holds no funds |
-| `LLMv1.sol` | `processBatch` CEI ordering (informational, not exploitable) | Informational | Accepted |
+| `LLMv1.sol` | `processBatch` state-update ordering — reentrancy hardening | Low | Open — fix on next upgrade |
 
 ---
 
@@ -35,6 +35,7 @@ Unfixed vulnerabilities are tracked privately via GitHub Security Advisories. Th
 - Solidity 0.8.27 — built-in overflow/underflow protection
 - Storage layout preserved across v3→v4 upgrade (gap 49 → 48 slots)
 - Merkle proof replay protection in `LLMv1` via `processedBatches` mapping
+- **Planned (next `LLMv1` upgrade):** set `processedBatches` before the provider-payment loop (CEI) or add `nonReentrant` to `processBatch`
 
 ---
 

--- a/scw_js/SECURITY.md
+++ b/scw_js/SECURITY.md
@@ -18,10 +18,10 @@ Serverless functions in `scw_js/`. See [../.github/THREAT_MODEL.md](../.github/T
 
 Unfixed vulnerabilities are tracked privately via GitHub Security Advisories. The table below lists them without attack-vector detail.
 
-| Function | Area | Severity | Status |
-|---|---|---|---|
-| `sc_llm` / `llm_service` | Pre-charge balance gate weaker than the settlement requirement | Medium | Open — tracked privately |
-| `genimg_x402_token` | Resource delivered before payment settlement is confirmed | Medium | Open — tracked privately |
+| Function                 | Area                                                           | Severity | Status                   |
+| ------------------------ | -------------------------------------------------------------- | -------- | ------------------------ |
+| `sc_llm` / `llm_service` | Pre-charge balance gate weaker than the settlement requirement | Medium   | Open — tracked privately |
+| `genimg_x402_token`      | Resource delivered before payment settlement is confirmed      | Medium   | Open — tracked privately |
 
 ---
 

--- a/scw_js/SECURITY.md
+++ b/scw_js/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not open a public GitHub issue** for security vulnerabilities.
+
+Report privately via [GitHub Security Advisories](https://github.com/fretchen/fretchen.github.io/security/advisories/new). You will receive a response within 7 days.
+
+---
+
+## Scope
+
+Serverless functions in `scw_js/`. See [../.github/THREAT_MODEL.md](../.github/THREAT_MODEL.md) for the full threat model, asset inventory, and blast radius analysis.
+
+---
+
+## Known Open Issues
+
+Unfixed vulnerabilities are tracked privately via GitHub Security Advisories. The table below lists them without attack-vector detail.
+
+| Function | Area | Severity | Status |
+|---|---|---|---|
+| `sc_llm` / `llm_service` | Pre-charge balance gate weaker than the settlement requirement | Medium | Open — tracked privately |
+| `genimg_x402_token` | Resource delivered before payment settlement is confirmed | Medium | Open — tracked privately |
+
+---
+
+## Mitigations in Place
+
+- Wallet authentication via signed-message bearer tokens with a bounded freshness window (`auth_utils.ts` — timestamped message, address match, signature verification)
+- EIP-3009 nonce binding enforces recipient/amount on settlement (facilitator + Splitter), so a relayer cannot redirect funds
+- Image metadata URLs validated against an allowlisted host before fetch (`genimg_x402_token.ts`)
+- Secrets supplied via Scaleway secret env vars, never committed; CORS handled per-function


### PR DESCRIPTION
# Threat model overhaul + security scan findings

## Summary

- Restructured `.github/THREAT_MODEL.md` to align with the OWASP four-question framework and the values of the Threat Modeling Manifesto — the document now explicitly declares its structure and reads as a maintained, living artifact rather than a one-time audit snapshot.
- Added a new §5 "Attack Techniques by Surface" anchored to OWASP Smart Contract Top 10 (2025) and OWASP API Security Top 10 (2023), curated to only live categories for this project.
- Re-ordered sections so the structure follows the four questions naturally (assets → blast radius → actors → trust boundaries → techniques → findings → mitigations).
- Rewrote §4 Trust Boundaries to explicitly name itself the attack-surface map and thread it to §3 actors.
- Created `scw_js/SECURITY.md` (mirrors `eth/SECURITY.md` structure) to hold serverless findings after a threat-model-driven code scan of `eth/` and `scw_js/`.
- Updated `eth/SECURITY.md` to promote the LLMv1 `processBatch` CEI finding from "Informational/Accepted" to "Low/Open — fix on next upgrade."
- Added a OWASP attack-surface shortcut to `.github/CVE_TRIAGE.md` to speed up reachability judgment.

## Changed files

| File | Change |
|---|---|
| `.github/THREAT_MODEL.md` | Major restructure: OWASP framing table, new §5 attack-techniques section, EIP3009 Splitter as testnet asset, §8 review triggers, updated blast-radius and CIA rows |
| `eth/SECURITY.md` | LLMv1 `processBatch` CEI row: Informational → Low/Open; added planned-fix note |
| `scw_js/SECURITY.md` | **New file** — rough entries for two Medium serverless findings (LLM balance gate, genimg deliver-before-settle); full detail tracked privately via GHSA |
| `.github/CVE_TRIAGE.md` | Added reachability shortcut via OWASP §5 surface map |

## Findings documented (not fixed)

Two Medium serverless findings are recorded roughly in `scw_js/SECURITY.md`; full exploit detail is captured in private GitHub Security Advisories (not committed):

1. **LLM flat balance gate** (`sc_llm` / `llm_service`) — pre-charge check uses a flat minimum rather than the request cost plus pending unsettled liability, enabling free LLM usage and a batch-settlement stall.
2. **genimg deliver-before-settle** (`genimg_x402_token`) — NFT and image are delivered before payment settlement, with settlement errors swallowed as non-critical.

One Low contract finding in `eth/SECURITY.md`:

3. **LLMv1 `processBatch` CEI ordering** — `processedBatches` is set after the provider payment loop; hardening deferred to next upgrade cycle.

## Test plan

- [ ] Read `.github/THREAT_MODEL.md` top-to-bottom and confirm the four-question table at the top matches the section layout
- [ ] Confirm `scw_js/SECURITY.md` has no attack-vector detail (rough table only — component, area, severity, status)
- [ ] Confirm `eth/SECURITY.md` LLMv1 row reads "Low | Open — fix on next upgrade"
- [ ] Grep committed files for phrases like "stalls the whole batch", "free usage", "step-by-step": `git diff main...threat_model -- '*.md' | grep -i "stalls\|free usage\|repro\|step-by-step"` — should return nothing
- [ ] Confirm the two scratchpad GHSA drafts are NOT under the repo tree (`find . -name "ghsa-*.md"` returns nothing)
